### PR TITLE
Feature/login page grid

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -90,6 +90,7 @@ export function localStorageSyncWrapper(reducer: any) {
     MatSnackBarModule,
     MatCardModule,
     MatListModule,
+    MatGridListModule,
     MatMenuModule,
     MatSidenavModule,
     MatTableModule,

--- a/src/app/users/login/login.component.html
+++ b/src/app/users/login/login.component.html
@@ -1,17 +1,21 @@
-<mat-card>
-  <form [formGroup]="loginForm" (ngSubmit)="doADLogin($event)" class="ui form">
-    <img src="assets/images/esslogo.png">
-    <div class="field">
-      <label for="emailInput">Username:</label>
-      <input id="emailInput" formControlName="username" class="form-control" type="text" placeholder="Username">
-    </div>
-    <div class="field">
-      <label for="pwdInput">Password:</label>
-      <input id="pwdInput" formControlName="password" type="password" class="form-control" placeholder="Password">
-    </div>
-    <button type="submit" [ngClass]="{'loading': loading$ | async}" class="ui button login-btn" id="login-btn">Log in</button>
-    
-    <mat-checkbox name="rememberMe">Remember me</mat-checkbox>
-  </form>
-  <img src="assets/images/ess-site.jpg">
-</mat-card>
+<mat-grid-list cols="2" rowHeight="500px">
+  <mat-grid-tile>
+    <form [formGroup]="loginForm" (ngSubmit)="doADLogin($event)" class="ui form">
+      <img src="assets/images/esslogo.png">
+      <div class="field">
+        <label for="emailInput">Username:</label>
+        <input id="emailInput" formControlName="username" class="form-control" type="text" placeholder="Username">
+      </div>
+      <div class="field">
+        <label for="pwdInput">Password:</label>
+        <input id="pwdInput" formControlName="password" type="password" class="form-control" placeholder="Password">
+      </div>
+      <button type="submit" [ngClass]="{'loading': loading$ | async}" class="ui button login-btn" id="login-btn">Log in
+      </button>
+
+      <mat-checkbox name="rememberMe">Remember me</mat-checkbox>
+    </form>
+  </mat-grid-tile>
+  <mat-grid-tile>
+    <img src="assets/images/ess-site.jpg">
+  </mat-grid-tile>

--- a/src/app/users/login/login.component.spec.ts
+++ b/src/app/users/login/login.component.spec.ts
@@ -7,7 +7,7 @@ import {LoopBackAuth} from 'shared/sdk/services';
 
 import {ADAuthService} from '../adauth.service';
 import {LoginComponent} from './login.component';
-import {MatCheckboxModule, MatCardModule} from '@angular/material';
+import {MatCheckboxModule, MatCardModule, MatGridListModule} from '@angular/material';
 
 /* tslint:disable:no-unused-variable */
 describe('LoginComponent', () => {
@@ -31,7 +31,7 @@ describe('LoginComponent', () => {
       }
     });
     TestBed.configureTestingModule({
-      imports: [ReactiveFormsModule, StoreModule.forRoot({}), MatCheckboxModule, MatCardModule],
+      imports: [ReactiveFormsModule, StoreModule.forRoot({}), MatCheckboxModule, MatCardModule, MatGridListModule],
       declarations: [LoginComponent]
     });
     TestBed.compileComponents();

--- a/src/app/users/login/login.component.spec.ts
+++ b/src/app/users/login/login.component.spec.ts
@@ -7,7 +7,7 @@ import {LoopBackAuth} from 'shared/sdk/services';
 
 import {ADAuthService} from '../adauth.service';
 import {LoginComponent} from './login.component';
-import { MatCheckboxModule, MatCardModule } from '@angular/material';
+import {MatCheckboxModule, MatCardModule} from '@angular/material';
 
 /* tslint:disable:no-unused-variable */
 describe('LoginComponent', () => {
@@ -18,21 +18,21 @@ describe('LoginComponent', () => {
 
 
   beforeEach(async(() => {
-     TestBed.overrideComponent(LoginComponent, {
-    set: {
-      // These should sync up with what is in the constructor, they do NOT need to be provided in the config for the testing module
-      providers: [
-        { provide: ADAuthService, useClass: MockAuthService },
-        { provide: LoopBackAuth, useClass: MockLoopBackAuth },
-        { provide: ActivatedRoute, useClass: MockActivatedRoute },
-        { provide: Router, useClass: MockRouter },
-        { provide: Store, useClass: MockStore },
-      ]
-    }
+    TestBed.overrideComponent(LoginComponent, {
+      set: {
+        // These should sync up with what is in the constructor, they do NOT need to be provided in the config for the testing module
+        providers: [
+          {provide: ADAuthService, useClass: MockAuthService},
+          {provide: LoopBackAuth, useClass: MockLoopBackAuth},
+          {provide: ActivatedRoute, useClass: MockActivatedRoute},
+          {provide: Router, useClass: MockRouter},
+          {provide: Store, useClass: MockStore},
+        ]
+      }
     });
     TestBed.configureTestingModule({
-      imports: [ ReactiveFormsModule, StoreModule.forRoot({}), MatCheckboxModule, MatCardModule ],
-      declarations: [ LoginComponent ]
+      imports: [ReactiveFormsModule, StoreModule.forRoot({}), MatCheckboxModule, MatCardModule],
+      declarations: [LoginComponent]
     });
     TestBed.compileComponents();
   }));
@@ -45,14 +45,14 @@ describe('LoginComponent', () => {
     // el = de.nativeElement;
   });
 
-    it('should create component', () => {
-      expect(component).toBeTruthy();
-    });
+  it('should create component', () => {
+    expect(component).toBeTruthy();
+  });
 
 
   it('should contain username and password fields', () => {
-      const compiled = fixture.debugElement.nativeElement;
-      expect(compiled.querySelector('form').textContent).toContain('Username');
-      expect(compiled.querySelector('form').textContent).toContain('Password');
+    const compiled = fixture.debugElement.nativeElement;
+    expect(compiled.querySelector('form').textContent).toContain('Username');
+    expect(compiled.querySelector('form').textContent).toContain('Password');
   });
 });

--- a/src/app/users/login/login.component.ts
+++ b/src/app/users/login/login.component.ts
@@ -7,6 +7,8 @@ import { Subscription } from 'rxjs';
 import { filter} from 'rxjs/operators';
 import { getIsLoggedIn, getIsLoggingIn } from 'state-management/selectors/users.selectors';
 
+import {MatGridListModule, MatCardModule} from '@angular/material';
+
 interface LoginForm {
   username: string;
   password: string;
@@ -37,7 +39,7 @@ export class LoginComponent implements OnInit, OnDestroy {
 
   private loading$ = this.store.pipe(select(getIsLoggingIn));
   private hasUser$ = this.store.pipe(select(getIsLoggedIn), filter(is => is));
-  
+
   private proceedSubscription: Subscription = null;
 
   /**
@@ -55,7 +57,7 @@ export class LoginComponent implements OnInit, OnDestroy {
     private store: Store<any>
   ) {
     //this.returnUrl = this.route.snapshot.queryParams['returnUrl'] || '/';
-    
+
     /*this.store.select(selectors.users.getCurrentUser)
     .subscribe(result => {
       console.log(result);

--- a/src/app/users/users.module.ts
+++ b/src/app/users/users.module.ts
@@ -8,9 +8,9 @@ import {UserSettingsComponent} from 'users/user-settings/user-settings.component
 import {ADAuthService} from './adauth.service';
 
 import {SharedCatanieModule} from 'shared/shared.module';
-import { StoreModule } from '@ngrx/store';
-import { userReducer } from 'state-management/reducers/user.reducer';
-import { MatCardModule, MatCheckboxModule } from '@angular/material';
+import {StoreModule} from '@ngrx/store';
+import {userReducer} from 'state-management/reducers/user.reducer';
+import {MatCardModule, MatCheckboxModule, MatGridListModule} from '@angular/material';
 
 @NgModule({
   imports: [
@@ -20,6 +20,7 @@ import { MatCardModule, MatCheckboxModule } from '@angular/material';
     ReactiveFormsModule,
     MatCardModule,
     MatCheckboxModule,
+    MatGridListModule,
     StoreModule.forFeature('users', userReducer),
   ],
   declarations: [
@@ -29,4 +30,5 @@ import { MatCardModule, MatCheckboxModule } from '@angular/material';
   ],
   providers: [ADAuthService]
 })
-export class UsersModule { }
+export class UsersModule {
+}


### PR DESCRIPTION
## Description

Move site image back to right hand side of login screen

## Motivation

mat-card config has moved login site photo to bottom of login form

## Fixes:

* switched from matcard to matgridlist for front page 

## Changes:

* changes made

## Tests included/Docs Updated?

[]  Included for each change/fix?
[x] Passing? (Merge will not be approved unless this is checked) 
[]  Docs updated?
[] New packages used/requires npm install? 

## Extra Information/Screenshots
![screen shot 2018-07-17 at 11 55 51](https://user-images.githubusercontent.com/16783958/42810529-70024b20-89b8-11e8-815d-010d2d0cc6de.png)
![screen shot 2018-07-17 at 11 55 56](https://user-images.githubusercontent.com/16783958/42810530-702e8f82-89b8-11e8-916d-881996a8395b.png)
