### PR TITLE
Feature/improve breadcrumb

### DIFF
--- a/e2e/dataset/dataset.po.ts
+++ b/e2e/dataset/dataset.po.ts
@@ -2,11 +2,11 @@ import { browser } from 'protractor';
 
 export class DatasetDetailPage {
 
-  constructor(path = '/dataset/' + browser.params.pid) {
+  constructor(path = '/datasets/' + browser.params.pid) {
       this.navigateTo(path);
   }
 
-  navigateTo(path = '/dataset/' + browser.params.pid) {
+  navigateTo(path = '/datasets/' + browser.params.pid) {
     return browser.get(path);
   }
 }

--- a/src/app/app-routing/app-routing.module.ts
+++ b/src/app/app-routing/app-routing.module.ts
@@ -31,12 +31,12 @@ export const routes: Routes = [
   { path: 'login', component: LoginComponent },
   { path: 'logout', component: AppComponent, canActivate: [AuthCheck] },
 
-  { path: 'dataset', redirectTo: '/datasets', pathMatch: 'full' },
+  // { path: 'dataset', redirectTo: '/datasets', pathMatch: 'full' },
   { path: 'datasets',  component: DashboardComponent, canActivate: [AuthCheck], },
   { path: 'datasets/batch', component: BatchViewComponent, canActivate: [AuthCheck] },
-  { path: 'dataset/:id', component: DatasetDetailComponent, canActivate: [AuthCheck] },
-  { path: 'dataset/:id/datablocks', component: DatablocksComponent, canActivate: [AuthCheck] },
-  { path: 'dataset/:id/datafiles', component: DatafilesComponent, canActivate: [AuthCheck] },
+  { path: 'datasets/:id', component: DatasetDetailComponent, canActivate: [AuthCheck] },
+  { path: 'datasets/:id/datablocks', component: DatablocksComponent, canActivate: [AuthCheck] },
+  { path: 'datasets/:id/datafiles', component: DatafilesComponent, canActivate: [AuthCheck] },
 
   { path: 'proposals', component: ListProposalsPageComponent, canActivate: [AuthCheck] },
   { path: 'proposals/:id', component: ViewProposalPageComponent, canActivate: [AuthCheck] },

--- a/src/app/datasets/dataset-table/dataset-table.component.ts
+++ b/src/app/datasets/dataset-table/dataset-table.component.ts
@@ -326,7 +326,7 @@ export class DatasetTableComponent implements OnInit, OnDestroy {
 
   onClick(dataset: Dataset): void {
     const pid = encodeURIComponent(dataset.pid);
-    this.router.navigateByUrl("/dataset/" + pid);
+    this.router.navigateByUrl("/datasets/" + pid);
   }
 
   isSelected(dataset: Dataset): boolean {

--- a/src/app/shared/modules/breadcrumb/breadcrumb.component.html
+++ b/src/app/shared/modules/breadcrumb/breadcrumb.component.html
@@ -1,4 +1,4 @@
-<div class="ui breadcrumb" *ngIf="breadcrumbs && breadcrumbs.length > 0">
+<div class="ui breadcrumb" *ngIf="(shouldDisplay$ | async) && breadcrumbs && breadcrumbs.length > 0">
   <!-- <a class="section" [routerLink]="['/datasets']">Home</a> -->
   <!-- <div class="divider"> / </div> -->
   <hr>

--- a/src/app/shared/modules/breadcrumb/breadcrumb.component.ts
+++ b/src/app/shared/modules/breadcrumb/breadcrumb.component.ts
@@ -11,7 +11,7 @@ import {
 import { TitleCasePipe } from '../../pipes/index';
 import { Store, select } from '@ngrx/store';
 import * as rison from 'rison';
-import { getViewMode, getFilters, getIsEmptySelection } from 'state-management/selectors/datasets.selectors';
+import { getViewMode, getFilters } from 'state-management/selectors/datasets.selectors';
 import { AppState } from 'state-management/state/app.store';
 import { take, filter, map } from 'rxjs/operators';
 


### PR DESCRIPTION
## Description

Makes navigation more consistent by:

* Now only using `/datasets[/xxx]` paths. Before both `/datasets` and `/dataset/xxx` were used.
* Hooked up breadcrumb component to the store and made it responsible for not displaying when URL is `/datasets`

This fixes the going-back bug in the batch view.