### PR TITLE
remove decimal places in filesize

### DIFF
--- a/src/app/shared/pipes/filesize.pipe.spec.ts
+++ b/src/app/shared/pipes/filesize.pipe.spec.ts
@@ -8,7 +8,7 @@ describe("Pipe: FileSize", () => {
   });
 
   it("converts properly", () => {
-    expect(pipe.transform("3746356")).toBe("3.57 MB");
+    expect(pipe.transform("3746356")).toBe("4 MB");
   });
 
   it("converts empty string to 0 B", () => {

--- a/src/app/shared/pipes/filesize.pipe.ts
+++ b/src/app/shared/pipes/filesize.pipe.ts
@@ -1,9 +1,9 @@
 import { Pipe, PipeTransform } from "@angular/core";
 import * as filesize from "filesize";
 
-@Pipe({ name: "filesize" })
+@Pipe({name: "filesize"})
 export class FileSizePipe implements PipeTransform {
   transform(value: string): any {
-    return filesize(value || 0);
+    return filesize(value || 0, {round: 0});
   }
 }


### PR DESCRIPTION
## Description

Removing extra decimal places in data tables

## Motivation

Data table looks cluttered, only rough estimate of filesize is necessary

## Fixes:

* Items added

## Changes:

* changes made

## Tests included/Docs Updated?

[]  Included for each change/fix?
[] Passing? (Merge will not be approved unless this is checked) 
[]  Docs updated?
[] New packages used/requires npm install? 

## Extra Information/Screenshots
