### PR TITLE
Implemented optional, configurable multiple download

### DIFF
--- a/src/app/app-config.module.ts
+++ b/src/app/app-config.module.ts
@@ -12,6 +12,8 @@ export class AppConfig {
   editMetadataEnabled: boolean;
   facility: string;
   shoppingCartEnabled: boolean;
+  multipleDownloadEnabled: boolean;
+  multipleDownloadAction?: string;
 }
 
 export const APP_DI_CONFIG: AppConfig = {
@@ -22,7 +24,9 @@ export const APP_DI_CONFIG: AppConfig = {
   archiveWorkflowEnabled: environment["archiveWorkflowEnabled"] || null,
   editMetadataEnabled: environment["editMetadataEnabled"] || null,
   facility: environment["facility"] || null,
-  shoppingCartEnabled: environment["shoppingCartEnabled"] || false
+  shoppingCartEnabled: environment["shoppingCartEnabled"] || false,
+  multipleDownloadEnabled: environment["multipleDownloadEnabled"] || false,
+  multipleDownloadAction: environment["multipleDownloadAction"]
 };
 
 @NgModule({

--- a/src/app/datasets/datafiles/datafiles.component.css
+++ b/src/app/datasets/datafiles/datafiles.component.css
@@ -1,0 +1,18 @@
+.mat-column-select {
+    flex-grow: 0;
+    overflow: visible; /* Needed to prevent offsetting of the checkbox when clicking */
+    padding-right: 1.5em;
+
+}
+
+button[type=submit] {
+    margin-bottom: 1em;
+    float: right;
+}
+
+.nbr-of-files {
+    float: left;
+    transform: translateY(50%);
+    margin-bottom: 1em;
+    font-size: larger;
+}

--- a/src/app/datasets/datafiles/datafiles.component.html
+++ b/src/app/datasets/datafiles/datafiles.component.html
@@ -1,35 +1,53 @@
-<h4>Orig Datablocks</h4>
-<datablocks-table [datablocks]="dataBlocks"></datablocks-table>
+<div class="datafiles-header">
+  <span [ngPlural]="count" class="nbr-of-files">
+    <ng-template ngPluralCase="=0">No datafiles.</ng-template>
+    <ng-template ngPluralCase="=1">1 datafile.</ng-template>
+    <ng-template ngPluralCase="other">{{ count }} datafiles.</ng-template>
+  </span>
 
-<h4>Datafiles</h4>
-<h5>Count: {{count}}</h5>
+  <form *ngIf="appConfig.multipleDownloadEnabled && appConfig.multipleDownloadAction" ngNoForm method="POST" [action]="appConfig.multipleDownloadAction">
+    <input type="hidden" name="base" [value]="(dataset$ | async).sourceFolder" />
+    <input *ngFor="let file of getSelectedFiles(); index as i" type="hidden" [name]="'files[' + i + ']'" [value]="file" />
+    <button [disabled]="isNoneSelected" type="submit" mat-flat-button>Download</button>
+  </form>
+
+  <div style="clear: both"></div>
+</div>
+
 <div *ngIf="dataBlocks && dataBlocks.length > 0">
-  <div class="example-container mat-elevation-z8">
+  <div class="example-container">
     <mat-table #table [dataSource]="dataSource">
-
-      <!--- Note that these columns can be defined in any order.
-            The actual rendered columns are set as a property on the row definition" -->
+      <ng-container matColumnDef="select">
+        <mat-header-cell *matHeaderCellDef>
+          <mat-checkbox [checked]="areAllSelected" (change)="onSelectAll($event)">
+          </mat-checkbox>
+        </mat-header-cell>
+        <mat-cell *matCellDef="let file">
+          <mat-checkbox [name]="file.path" [checked]="file.selected" (change)="onSelect($event, file)">
+          </mat-checkbox>
+        </mat-cell>
+      </ng-container>
 
       <ng-container matColumnDef="name">
-        <mat-header-cell *matHeaderCellDef> Path.</mat-header-cell>
-        <mat-cell *matCellDef="let element" matTooltip="{{element.path}}">
-          <a *ngIf="urlPrefix; else noLink" href="{{urlPrefix}}{{element.path}}">
-            {{element.path | slice:-15 }}
+        <mat-header-cell *matHeaderCellDef>Path</mat-header-cell>
+        <mat-cell *matCellDef="let file" matTooltip="{{file.path}}">
+          <a *ngIf="urlPrefix; else noLink" href="{{urlPrefix}}{{file.path}}">
+            {{file.path | slice:-15 }}
           </a>
           <ng-template #noLink>
-            {{element.path}}
+            {{file.path}}
           </ng-template>
         </mat-cell>
       </ng-container>
 
       <ng-container matColumnDef="path">
         <mat-header-cell *matHeaderCellDef>Time</mat-header-cell>
-        <mat-cell *matCellDef="let element">{{element.time | date: 'yyyy/MM/dd HH:mm'}}</mat-cell>
+        <mat-cell *matCellDef="let file">{{file.time | date: 'yyyy/MM/dd HH:mm'}}</mat-cell>
       </ng-container>
 
       <ng-container matColumnDef="size">
         <mat-header-cell *matHeaderCellDef>Size</mat-header-cell>
-        <mat-cell *matCellDef="let element">{{element.size | filesize}}</mat-cell>
+        <mat-cell *matCellDef="let file">{{file.size | filesize}}</mat-cell>
       </ng-container>
 
       <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
@@ -39,3 +57,6 @@
 
   <mat-paginator [pageSize]="30" [pageSizeOptions]="[10,30, 50, 100]" [length]="count"></mat-paginator>
 </div>
+
+<h4>Original Datablocks</h4>
+<datablocks-table [datablocks]="dataBlocks"></datablocks-table>

--- a/src/app/datasets/datafiles/datafiles.component.html
+++ b/src/app/datasets/datafiles/datafiles.component.html
@@ -5,7 +5,7 @@
     <ng-template ngPluralCase="other">{{ count }} datafiles.</ng-template>
   </span>
 
-  <form *ngIf="appConfig.multipleDownloadEnabled && appConfig.multipleDownloadAction" ngNoForm method="POST" [action]="appConfig.multipleDownloadAction">
+  <form *ngIf="multipleDownloadEnabled && multipleDownloadAction" ngNoForm method="POST" [action]="multipleDownloadAction">
     <input type="hidden" name="base" [value]="(dataset$ | async).sourceFolder" />
     <input *ngFor="let file of getSelectedFiles(); index as i" type="hidden" [name]="'files[' + i + ']'" [value]="file" />
     <button [disabled]="isNoneSelected" type="submit" mat-flat-button>Download</button>

--- a/src/app/datasets/datafiles/datafiles.component.ts
+++ b/src/app/datasets/datafiles/datafiles.component.ts
@@ -34,6 +34,9 @@ export class DatafilesComponent implements OnInit, AfterViewInit {
   areAllSelected: boolean = false;
   isNoneSelected: boolean = true;
 
+  multipleDownloadEnabled: boolean = this.appConfig.multipleDownloadEnabled;
+  multipleDownloadAction: string = this.appConfig.multipleDownloadAction;
+
   displayedColumns = (this.appConfig.multipleDownloadEnabled
     ? ["select"]
     : []

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -12,5 +12,7 @@ export const environment = {
   editMetadataEnabled: true,
   disabledDatasetColumns: [],
   facility: "ESS",
-  shoppingCartEnabled: false
+  shoppingCartEnabled: false,
+  multipleDownloadEnabled: true,
+  multipleDownloadAction: "http://0.0.0.0:9999/phpinfo.php"
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -13,6 +13,4 @@ export const environment = {
   disabledDatasetColumns: [],
   facility: "ESS",
   shoppingCartEnabled: false,
-  multipleDownloadEnabled: true,
-  multipleDownloadAction: "http://0.0.0.0:9999/phpinfo.php"
 };


### PR DESCRIPTION
## Description

Adds checkboxes to the datafile listing, plus a [Download] button that sends the user to a configurable external target where the file download can be completed.

Enable by adding the following to your environment file:

    multipleDownloadEnabled: true,
    multipleDownloadAction: "http://0.0.0.0:9999/whatever"

Upon clicking "Download", it sends a POST request to the external service where the data has the following format:

    {
        "base": "/data/group-2/4",
        "files": ["datafile_0.h5", "datafile_2.h5", "datafile_3.h5"]
    }
