### PR TITLE
Reintroduces margin between sidebar and dataset table

### DIFF
--- a/src/app/datasets/dashboard/dashboard.component.html
+++ b/src/app/datasets/dashboard/dashboard.component.html
@@ -1,5 +1,5 @@
 <div fxLayout="row" fxLayout.xs="column">
-  <div fxFlex="19">
+  <div fxFlex="19" style="margin-right: 1em">
     <datasets-filter></datasets-filter>
     <batch-card></batch-card>
   </div>


### PR DESCRIPTION
## Description

Reintroduces the tiny gap between the sidebar and the dataset table that was lost at some point.

### Before
![image](https://user-images.githubusercontent.com/113777/48491826-be123400-e828-11e8-8975-8d9474c7c73a.png)

### After 
![image](https://user-images.githubusercontent.com/113777/48491841-c7030580-e828-11e8-8e68-71e0edc7f7b5.png)
