### PR TITLE
specify rightalign in archive settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "ts-helpers": "^1.1.2",
     "ts-node": "^7.0.1",
     "tslint": "^5.11.0",
-    "typescript": "^3.1.6",
+    "typescript": "~3.1.6",
     "uglify-js": "^3.4.9",
     "webdriver-manager": "^12.1.0",
     "webpack": "^4.26.0",

--- a/src/app/policies/archive-settings/archive-settings.component.html
+++ b/src/app/policies/archive-settings/archive-settings.component.html
@@ -2,7 +2,7 @@
 </div>
 
 
-  <div class="button-group" align="end">
+  <div class="button-group">
     <ng-container *ngIf="editEnabled" >
       <button mat-button mat-button (click)="onEditClick()" color="primary">
         <mat-icon >edit</mat-icon> Edit Selection
@@ -66,11 +66,11 @@
     </ng-container>
 
     <ng-container matColumnDef="retrieveEmailNotification">
-      <mat-header-cell *matHeaderCellDef>Retrive Email Notification</mat-header-cell>
+      <mat-header-cell *matHeaderCellDef>Retrieve Email Notification</mat-header-cell>
       <mat-cell *matCellDef="let policy">{{policy.retrieveEmailNotification}}</mat-cell>
     </ng-container>
     <ng-container matColumnDef="retrieveEmailsToBeNotified">
-      <mat-header-cell *matHeaderCellDef>Retrive Emails to be Notified</mat-header-cell>
+      <mat-header-cell *matHeaderCellDef>Retrieve Emails to be Notified</mat-header-cell>
       <mat-cell *matCellDef="let policy">{{policy.retrieveEmailsToBeNotified}}</mat-cell>
     </ng-container>
 

--- a/src/app/policies/archive-settings/archive-settings.component.scss
+++ b/src/app/policies/archive-settings/archive-settings.component.scss
@@ -1,5 +1,8 @@
 @import '../../../theme.scss';
 
+.button-group {
+  float: right;
+}
 $ds-archive: mat-palette($mat-green, 600);
 
 mat-cell, .mat-header-cell {


### PR DESCRIPTION
## Description

Add float right to archive setting button group

## Motivation

Firefox was not respecting align=right to changed to css float right

## Fixes:

* Items added

## Changes:

* changes made

## Tests included/Docs Updated?

[]  Included for each change/fix?
[] Passing? (Merge will not be approved unless this is checked) 
[]  Docs updated?
[] New packages used/requires npm install? 

## Extra Information/Screenshots
