### PR TITLE
Dataset filters

### DIFF
--- a/src/app/datasets/datasets-filter/datasets-filter.component.html
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.html
@@ -22,10 +22,10 @@
           }} <mat-icon matChipRemove>cancel</mat-icon>
         </mat-chip>
       </mat-chip-list>
-      <input matInput class="location-input" [matChipInputFor]="locationChipList" placeholder="Location" aria-label="Location" [matAutocomplete]="loc">
+      <input (input)="locationInpuKeyUp$.next($event.target.value)" [value]="locationInpuKeyUp$ | async" matInput class="location-input" [matChipInputFor]="locationChipList" placeholder="Location" aria-label="Location" [matAutocomplete]="loc">
 
       <mat-autocomplete #loc="matAutocomplete">
-        <mat-option class="options" (onSelectionChange)="locationSelected(getFacetId(fc))" *ngFor="let fc of locationFacetCounts$ | async">
+        <mat-option class="options" (onSelectionChange)="locationSelected(getFacetId(fc))" *ngFor="let fc of locationSuggestions$ | async">
           <span>{{ getFacetId(fc, 'No Location') }} | </span>
           <small>{{ getFacetCount(fc) }}</small>
         </mat-option>
@@ -39,9 +39,10 @@
           }}<mat-icon matChipRemove>cancel</mat-icon>
         </mat-chip>
       </mat-chip-list>
-      <input (input)="groupInpuKeyUp$.next($event.target.value)" [value]="groupInpuKeyUp$ | async" id="fu" matInput class="group-input" [matChipInputFor]="groupChipList" placeholder="Group" aria-label="Group" [matAutocomplete]="grp">
+      <input (input)="groupInpuKeyUp$.next($event.target.value)" [value]="groupInpuKeyUp$ | async" matInput class="group-input" [matChipInputFor]="groupChipList" placeholder="Group" aria-label="Group" [matAutocomplete]="grp">
+
       <mat-autocomplete autoActiveFirstOption #grp="matAutocomplete">
-        <mat-option class="options" (onSelectionChange)="groupSelected(getFacetId(fc))" *ngFor="let fc of filteredGroups$ | async">
+        <mat-option class="options" (onSelectionChange)="groupSelected(getFacetId(fc))" *ngFor="let fc of groupSuggestions$ | async">
           <span>{{ getFacetId(fc, 'No Group') }}</span> |
           <small>{{ getFacetCount(fc) }}</small>
         </mat-option>
@@ -55,10 +56,10 @@
           }}<mat-icon matChipRemove>cancel</mat-icon>
         </mat-chip>
       </mat-chip-list>
-      <input matInput class="type-input" [matChipInputFor]="typeChipList" placeholder="Type" aria-label="Type" [matAutocomplete]="type">
+      <input (input)="typeInpuKeyUp$.next($event.target.value)" [value]="typeInpuKeyUp$ | async" matInput class="type-input" [matChipInputFor]="typeChipList" placeholder="Type" aria-label="Type" [matAutocomplete]="type">
 
       <mat-autocomplete #type="matAutocomplete">
-        <mat-option class="options" (onSelectionChange)="typeSelected(getFacetId(fc))" *ngFor="let fc of typeFacetCounts$ | async">
+        <mat-option class="options" (onSelectionChange)="typeSelected(getFacetId(fc))" *ngFor="let fc of typeSuggestions$ | async">
           <span>{{ getFacetId(fc, 'No Type') }}</span> |
           <small>{{ getFacetCount(fc) }}</small>
         </mat-option>
@@ -72,9 +73,9 @@
           }}<mat-icon matChipRemove>cancel</mat-icon>
         </mat-chip>
       </mat-chip-list>
-      <input matInput class="keyword-input" [matChipInputFor]="keywordChipList" placeholder="Keywords" aria-label="Keywords"  [matAutocomplete]="kw">
+      <input (input)="keywordsInpuKeyUp$.next($event.target.value)" [value]="keywordsInpuKeyUp$ | async" matInput class="keyword-input" [matChipInputFor]="keywordChipList" placeholder="Keywords" aria-label="Keywords"  [matAutocomplete]="kw">
       <mat-autocomplete #kw="matAutocomplete">
-        <mat-option class="options" (onSelectionChange)="keywordSelected(getFacetId(fc))" *ngFor="let fc of keywordFacetCounts$ | async">
+        <mat-option class="options" (onSelectionChange)="keywordSelected(getFacetId(fc))" *ngFor="let fc of keywordsSuggestions$ | async">
           <span>{{ getFacetId(fc, 'No Keywords') }}</span>
           <small>: {{ getFacetCount(fc) }}</small>
         </mat-option>

--- a/src/app/datasets/datasets-filter/datasets-filter.component.html
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.html
@@ -22,9 +22,9 @@
           }} <mat-icon matChipRemove>cancel</mat-icon>
         </mat-chip>
       </mat-chip-list>
-      <input (input)="locationInpuKeyUp$.next($event.target.value)" [value]="locationInpuKeyUp$ | async" matInput class="location-input" [matChipInputFor]="locationChipList" placeholder="Location" aria-label="Location" [matAutocomplete]="loc">
+      <input (input)="locationInput$.next($event.target.value)" [value]="locationInput$ | async" matInput class="location-input" [matChipInputFor]="locationChipList" placeholder="Location" aria-label="Location" [matAutocomplete]="loc">
 
-      <mat-autocomplete #loc="matAutocomplete">
+      <mat-autocomplete autoActiveFirstOption #loc="matAutocomplete">
         <mat-option class="options" (onSelectionChange)="locationSelected(getFacetId(fc))" *ngFor="let fc of locationSuggestions$ | async">
           <span>{{ getFacetId(fc, 'No Location') }} | </span>
           <small>{{ getFacetCount(fc) }}</small>
@@ -39,7 +39,7 @@
           }}<mat-icon matChipRemove>cancel</mat-icon>
         </mat-chip>
       </mat-chip-list>
-      <input (input)="groupInpuKeyUp$.next($event.target.value)" [value]="groupInpuKeyUp$ | async" matInput class="group-input" [matChipInputFor]="groupChipList" placeholder="Group" aria-label="Group" [matAutocomplete]="grp">
+      <input (input)="groupInput$.next($event.target.value)" [value]="groupInput$ | async" matInput class="group-input" [matChipInputFor]="groupChipList" placeholder="Group" aria-label="Group" [matAutocomplete]="grp">
 
       <mat-autocomplete autoActiveFirstOption #grp="matAutocomplete">
         <mat-option class="options" (onSelectionChange)="groupSelected(getFacetId(fc))" *ngFor="let fc of groupSuggestions$ | async">
@@ -56,9 +56,9 @@
           }}<mat-icon matChipRemove>cancel</mat-icon>
         </mat-chip>
       </mat-chip-list>
-      <input (input)="typeInpuKeyUp$.next($event.target.value)" [value]="typeInpuKeyUp$ | async" matInput class="type-input" [matChipInputFor]="typeChipList" placeholder="Type" aria-label="Type" [matAutocomplete]="type">
+      <input (input)="typeInput$.next($event.target.value)" [value]="typeInput$ | async" matInput class="type-input" [matChipInputFor]="typeChipList" placeholder="Type" aria-label="Type" [matAutocomplete]="type">
 
-      <mat-autocomplete #type="matAutocomplete">
+      <mat-autocomplete autoActiveFirstOption #type="matAutocomplete">
         <mat-option class="options" (onSelectionChange)="typeSelected(getFacetId(fc))" *ngFor="let fc of typeSuggestions$ | async">
           <span>{{ getFacetId(fc, 'No Type') }}</span> |
           <small>{{ getFacetCount(fc) }}</small>
@@ -73,8 +73,8 @@
           }}<mat-icon matChipRemove>cancel</mat-icon>
         </mat-chip>
       </mat-chip-list>
-      <input (input)="keywordsInpuKeyUp$.next($event.target.value)" [value]="keywordsInpuKeyUp$ | async" matInput class="keyword-input" [matChipInputFor]="keywordChipList" placeholder="Keywords" aria-label="Keywords"  [matAutocomplete]="kw">
-      <mat-autocomplete #kw="matAutocomplete">
+      <input (input)="keywordsInput$.next($event.target.value)" [value]="keywordsInput$ | async" matInput class="keyword-input" [matChipInputFor]="keywordChipList" placeholder="Keywords" aria-label="Keywords"  [matAutocomplete]="kw">
+      <mat-autocomplete autoActiveFirstOption #kw="matAutocomplete">
         <mat-option class="options" (onSelectionChange)="keywordSelected(getFacetId(fc))" *ngFor="let fc of keywordsSuggestions$ | async">
           <span>{{ getFacetId(fc, 'No Keywords') }}</span>
           <small>: {{ getFacetCount(fc) }}</small>

--- a/src/app/datasets/datasets-filter/datasets-filter.component.html
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.html
@@ -1,5 +1,4 @@
 <mat-card>
-  <form class="example-form">
     <div class="section-container">
       <span class="title">Filter Results</span>
       <button [disabled]="!(hasAppliedFilters$ | async)" mat-button class="clear-button" color="primary" (click)="clearFacets()">
@@ -40,10 +39,9 @@
           }}<mat-icon matChipRemove>cancel</mat-icon>
         </mat-chip>
       </mat-chip-list>
-      <input matInput class="group-input" [matChipInputFor]="groupChipList" placeholder="Group" aria-label="Group" [matAutocomplete]="grp">
-
-      <mat-autocomplete #grp="matAutocomplete">
-        <mat-option class="options" (onSelectionChange)="groupSelected(getFacetId(fc))" *ngFor="let fc of groupFacetCounts$ | async">
+      <input (input)="groupInpuKeyUp$.next($event.target.value)" matInput class="group-input" [matChipInputFor]="groupChipList" placeholder="Group" aria-label="Group" [matAutocomplete]="grp">
+      <mat-autocomplete autoActiveFirstOption #grp="matAutocomplete">
+        <mat-option class="options" (onSelectionChange)="groupSelected(getFacetId(fc))" *ngFor="let fc of filteredGroups$ | async">
           <span>{{ getFacetId(fc, 'No Group') }}</span> |
           <small>{{ getFacetCount(fc) }}</small>
         </mat-option>
@@ -122,5 +120,4 @@
         </mat-chip>
       </mat-chip-list>
     </div>
-  </form>
 </mat-card>

--- a/src/app/datasets/datasets-filter/datasets-filter.component.html
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.html
@@ -39,7 +39,7 @@
           }}<mat-icon matChipRemove>cancel</mat-icon>
         </mat-chip>
       </mat-chip-list>
-      <input (input)="groupInpuKeyUp$.next($event.target.value)" matInput class="group-input" [matChipInputFor]="groupChipList" placeholder="Group" aria-label="Group" [matAutocomplete]="grp">
+      <input (input)="groupInpuKeyUp$.next($event.target.value)" [value]="groupInpuKeyUp$ | async" id="fu" matInput class="group-input" [matChipInputFor]="groupChipList" placeholder="Group" aria-label="Group" [matAutocomplete]="grp">
       <mat-autocomplete autoActiveFirstOption #grp="matAutocomplete">
         <mat-option class="options" (onSelectionChange)="groupSelected(getFacetId(fc))" *ngFor="let fc of filteredGroups$ | async">
           <span>{{ getFacetId(fc, 'No Group') }}</span> |

--- a/src/app/datasets/datasets-filter/datasets-filter.component.ts
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.ts
@@ -2,7 +2,8 @@ import { Component } from "@angular/core";
 import { MatDatepickerInputEvent, MatDialog } from "@angular/material";
 
 import { select, Store } from "@ngrx/store";
-import { debounceTime, distinctUntilChanged, skipWhile } from "rxjs/operators";
+import { debounceTime, distinctUntilChanged, skipWhile, withLatestFrom, map } from "rxjs/operators";
+
 
 import { FacetCount } from "state-management/state/datasets.store";
 import {
@@ -38,6 +39,7 @@ import {
   SetTextFilterAction
 } from "state-management/actions/datasets.actions";
 import { ScientificConditionDialogComponent } from "datasets/scientific-condition-dialog/scientific-condition-dialog.component";
+import { Subject, combineLatest } from "rxjs";
 
 type DateRange = {
   begin: Date;
@@ -65,6 +67,19 @@ export class DatasetsFilterComponent {
   scientificConditions$ = this.store.pipe(select(getScientificConditions));
 
 
+  groupInpuKeyUp$ = new Subject<string>();
+ 
+  filteredGroups$  = combineLatest(this.groupFacetCounts$, this.groupInpuKeyUp$).pipe(
+        map(([counts, filterString]) => {
+      console.log(counts);
+      console.log(filterString)
+      console.log("group-1".includes(filterString))
+      //return counts;
+      return counts.filter((count) => typeof count._id === "string" && count._id.includes(filterString));
+    })
+  )
+
+  
   hasAppliedFilters$ = this.store.pipe(select(getHasAppliedFilters));
 
   private searchTermSubscription = this.searchTerms$
@@ -87,7 +102,8 @@ export class DatasetsFilterComponent {
       this.store.dispatch(new AddKeywordFilterAction(terms));
     });
 
-  constructor(public dialog: MatDialog, private store: Store<any>) {}
+  constructor(public dialog: MatDialog, private store: Store<any>) {
+  }
 
   getFacetId(facetCount: FacetCount, fallback: string = null): string {
     const id = facetCount._id;

--- a/src/app/datasets/datasets-filter/datasets-filter.component.ts
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.ts
@@ -6,7 +6,6 @@ import {
   debounceTime,
   distinctUntilChanged,
   skipWhile,
-  withLatestFrom,
   map
 } from "rxjs/operators";
 
@@ -44,7 +43,7 @@ import {
   SetTextFilterAction
 } from "state-management/actions/datasets.actions";
 import { ScientificConditionDialogComponent } from "datasets/scientific-condition-dialog/scientific-condition-dialog.component";
-import { Subject, combineLatest, BehaviorSubject } from "rxjs";
+import { combineLatest, BehaviorSubject } from "rxjs";
 
 type DateRange = {
   begin: Date;
@@ -76,8 +75,6 @@ export class DatasetsFilterComponent {
   typeInpuKeyUp$ = new BehaviorSubject<string>("");
   keywordsInpuKeyUp$ = new BehaviorSubject<string>("");
 
-  //List of displayed suggestions. Based on groupFacetcounts, it filters out suggestions that have already been 
-  //added, as well as suggestions that don't includes the current text filter
   groupSuggestions$ = combineLatest(
     this.groupFacetCounts$,
     this.groupInpuKeyUp$,

--- a/src/app/datasets/datasets-filter/datasets-filter.component.ts
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.ts
@@ -52,6 +52,7 @@ type DateRange = {
   styleUrls: ["datasets-filter.component.css"]
 })
 export class DatasetsFilterComponent {
+
   locationFacetCounts$ = this.store.pipe(select(getLocationFacetCounts));
   groupFacetCounts$ = this.store.pipe(select(getGroupFacetCounts));
   typeFacetCounts$ = this.store.pipe(select(getTypeFacetCounts));
@@ -71,10 +72,6 @@ export class DatasetsFilterComponent {
  
   filteredGroups$  = combineLatest(this.groupFacetCounts$, this.groupInpuKeyUp$).pipe(
         map(([counts, filterString]) => {
-      console.log(counts);
-      console.log(filterString)
-      console.log("group-1".includes(filterString))
-      //return counts;
       return counts.filter((count) => typeof count._id === "string" && count._id.includes(filterString));
     })
   )
@@ -128,6 +125,7 @@ export class DatasetsFilterComponent {
 
   groupSelected(group: string) {
     this.store.dispatch(new AddGroupFilterAction(group));
+    this.groupInpuKeyUp$.next("");
   }
 
   groupRemoved(group: string) {


### PR DESCRIPTION
### Changes to dataset/filters

- Preventing form submit when pressing enter in the 'Text search'.
- For' Location', 'Group', 'Type' and 'Keywords' filters:
- - Show all suggestions when first selecting the (empty) field
- - When typing text, show only suggestions that match (contains) the typed text.
- - When pressing enter, automatically add the first (top) suggestion.
- - When adding a suggestion, clear the corresponding text field
- - After having added a suggestion, exclude this from future suggestions.