### PR TITLE
prevent error when multipledownload is enabled

### DIFF
--- a/src/app/datasets/datafiles/datafiles.component.ts
+++ b/src/app/datasets/datafiles/datafiles.component.ts
@@ -108,8 +108,8 @@ export class DatafilesComponent implements OnInit, AfterViewInit {
       return [];
     }
     return this.dataSource.data
-    .filter(file => file.selected)
-    .map(file => file.path);
+      .filter(file => file.selected)
+      .map(file => file.path);
   }
 
   updateSelectionStatus() {

--- a/src/app/datasets/datafiles/datafiles.component.ts
+++ b/src/app/datasets/datafiles/datafiles.component.ts
@@ -104,9 +104,12 @@ export class DatafilesComponent implements OnInit, AfterViewInit {
   }
 
   getSelectedFiles() {
+    if (!this.dataSource){
+      return [];
+    }
     return this.dataSource.data
-      .filter(file => file.selected)
-      .map(file => file.path);
+    .filter(file => file.selected)
+    .map(file => file.path);
   }
 
   updateSelectionStatus() {


### PR DESCRIPTION
The list of files no longer show up when multipledownload is enabled and has an action. This was caused by a call to getSelectedFiles() from the template prior to dataSource being initialized. 
I added a null check.