### PR TITLE
do not add modeFilter to facetQuery params

### DIFF
--- a/src/app/state-management/selectors/datasets.selectors.ts
+++ b/src/app/state-management/selectors/datasets.selectors.ts
@@ -214,7 +214,7 @@ export const getFullqueryParams = createSelector(getFilters, filter => {
 });
 
 export const getFullfacetsParams = createSelector(getFilters, filter => {
-  const { skip, limit, sortField, scientific, ...theRest } = filter;
+  const { skip, limit, sortField, scientific, modeToggle, ...theRest } = filter;
   const fields = restrictFilter(theRest);
   const facets = [
     "type",


### PR DESCRIPTION
## Description

forgot to exclude modeFilter from fullFacet query. Maybe there is a better way.

## Fixes:

datasets count/ fullFacet query



[] Included for each change/fix?
[x] Passing? (Merge will not be approved unless this is checked) 
[] Docs updated?
[] New packages used/requires npm install? 
[] Toggle added for new features?

