### PR TITLE
Share data with other users

### DIFF
--- a/src/app/datasets/datasets-filter/datasets-filter.component.ts
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.ts
@@ -76,23 +76,6 @@ export class DatasetsFilterComponent {
   typeInput$ = new BehaviorSubject<string>("");
   keywordsInput$ = new BehaviorSubject<string>("");
 
-  createSuggestionObserver(
-    facetCounts$: Observable<FacetCount[]>,
-    input$: BehaviorSubject<string>,
-    currentFilters$: Observable<string[]>
-  ): Observable<FacetCount[]> {
-    return combineLatest(facetCounts$, input$, currentFilters$).pipe(
-      map(([counts, filterString, currentFilters]) => {
-        if (!counts) return [];
-        return counts.filter(
-          count =>
-            typeof count._id === "string" &&
-            count._id.toLowerCase().includes(filterString.toLowerCase()) &&
-            currentFilters.indexOf(count._id) < 0
-        );
-      })
-    );
-  }
   groupSuggestions$ = this.createSuggestionObserver(
     this.groupFacetCounts$,
     this.groupInput$,
@@ -138,6 +121,24 @@ export class DatasetsFilterComponent {
     .subscribe(terms => {
       this.store.dispatch(new AddKeywordFilterAction(terms));
     });
+
+    createSuggestionObserver(
+      facetCounts$: Observable<FacetCount[]>,
+      input$: BehaviorSubject<string>,
+      currentFilters$: Observable<string[]>
+    ): Observable<FacetCount[]> {
+      return combineLatest(facetCounts$, input$, currentFilters$).pipe(
+        map(([counts, filterString, currentFilters]) => {
+          if (!counts) return [];
+          return counts.filter(
+            count =>
+              typeof count._id === "string" &&
+              count._id.toLowerCase().includes(filterString.toLowerCase()) &&
+              currentFilters.indexOf(count._id) < 0
+          );
+        })
+      );
+    }
 
   constructor(
     public dialog: MatDialog,

--- a/src/app/datasets/publish/publish.component.html
+++ b/src/app/datasets/publish/publish.component.html
@@ -103,13 +103,23 @@
       ></textarea>
     </mat-form-field>
 
-    <button
-      (click)="onPublish()"
-      mat-raised-button
-      color="primary"
-      [disabled]="!formIsValid()"
-    >
-      Publish
-    </button>
+    <div fxLayout="row" fxLayoutGap="20px">
+      <button
+        (click)="onPublish()"
+        mat-raised-button
+        color="primary"
+        [disabled]="!formIsValid()"
+      >
+        Publish
+      </button>
+      <button
+        (click)="onRegister()"
+        mat-raised-button
+        color="primary"
+        [disabled]="!formIsValid()"
+      >
+        Register
+      </button>
+    </div>
   </form>
 </mat-card>

--- a/src/app/datasets/publish/publish.component.ts
+++ b/src/app/datasets/publish/publish.component.ts
@@ -89,6 +89,10 @@ export class PublishComponent implements OnInit {
     });
   }
 
+
+  public onRegister() {
+  }
+
   addAuthor(event) {
     this.form.authors.push(event.value);
     event.input.value = "";


### PR DESCRIPTION
## Description

add the other user to a group, which you add to the accessGroups list. Then catanie would need to make a call to update the dataset by adding this group to the dataset's accessGroups and another can to create the group and its members. When the other user re-login he would see the dataset. One would need to discuss were the groups can be managed. This could be either in an IM System like AD or we would create a new group model inside loopback, which would manage these kind of ad hoc groups (i.e re-vive the accessGroups model or somethng similar). I guess this needs some more discussions.


[] Included for each change/fix?
[] Passing? (Merge will not be approved unless this is checked) 
[] Docs updated?
[] New packages used/requires npm install? 
[] Toggle added for new features?

