### PR TITLE
Removed property `showFirstLastButtons` from paginator

### DIFF
--- a/src/app/datasets/dataset-table/dataset-table.component.html
+++ b/src/app/datasets/dataset-table/dataset-table.component.html
@@ -75,7 +75,7 @@
     </button>
   </div>
   <mat-paginator [pageSizeOptions]="[30, 1000]" [pageIndex]="currentPage$ | async" [length]="datasetCount$ | async"
-    [pageSize]="datasetsPerPage$ | async" (page)="onPageChange($event)" showFirstLastButtons>
+    [pageSize]="datasetsPerPage$ | async" (page)="onPageChange($event)">
   </mat-paginator>
  </div>
 


### PR DESCRIPTION
## Description

Removed the 'showFirstLastButtons' property from the Dataset table paginator

## Motivation

Skipping breaks backend for large amounts of Datasets

## Changes:

* Removed 'showFirstLastButtons' from mat-paginator

## Tests included/Docs Updated?

[] Included for each change/fix?
[x] Passing? (Merge will not be approved unless this is checked) 
[] Docs updated?
[] New packages used/requires npm install? 
[] Toggle added for new features?

