### PR TITLE
Added showFirstLastButtons property to dataset table paginator

### DIFF
--- a/src/app/datasets/dataset-table/dataset-table.component.html
+++ b/src/app/datasets/dataset-table/dataset-table.component.html
@@ -75,7 +75,7 @@
     </button>
   </div>
   <mat-paginator [pageSizeOptions]="[30, 1000]" [pageIndex]="currentPage$ | async" [length]="datasetCount$ | async"
-    [pageSize]="datasetsPerPage$ | async" (page)="onPageChange($event)">
+    [pageSize]="datasetsPerPage$ | async" (page)="onPageChange($event)" showFirstLastButtons>
   </mat-paginator>
  </div>
 


### PR DESCRIPTION
## Description

Adds skip buttons to datasets table

## Motivation

Previously removed due to causing crashes in catamel when handling large amounts of datasets, should now be working.

## Changes:

* Added property 'showFirstLastButtons' to datasets table

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?

