### PR TITLE
Feature/drag and drop upload dataset attachments

### DIFF
--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -284,7 +284,8 @@
       <i class="material-icons"> insert_photo </i> Attachments
     </ng-template>
     <h3>Attachments</h3>
-    <app-file-picker></app-file-picker>
+    <app-file-dropzone></app-file-dropzone>
+    <!-- <app-file-picker></app-file-picker> -->
     <br />
     <ng-container
       *ngFor="let da of attachments; let i = index"

--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -285,7 +285,7 @@
     </ng-template>
     <h3>Attachments</h3>
     <app-file-dropzone></app-file-dropzone>
-    <!-- <app-file-picker></app-file-picker> -->
+    <app-file-picker></app-file-picker>
     <br />
     <ng-container
       *ngFor="let da of attachments; let i = index"

--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -294,7 +294,7 @@
       <mat-card class="attach-card">
         <img src="{{ da.thumbnail }}" style="width: 20em; height: 20em" />
         <mat-card-actions>
-          <button mat-raised-button (click)="delete(dataset.pid, da.id)">
+          <button mat-button (click)="delete(dataset.pid, da.id)">
             <mat-icon>delete</mat-icon>
           </button>
         </mat-card-actions>

--- a/src/app/datasets/dataset-detail/dataset-detail.component.scss
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.scss
@@ -19,23 +19,20 @@
   mat-card {
     width: 20em;
   }
-
-
 }
-
-.attach-card {
-  width: 22em;
-  float: left;
-  margin: 1em;
-}
-
-
-.file-picker {
-  width: 21em;
-  margin: 1em;
-}
-
 
 .material-icons {
   vertical-align: middle;
+}
+
+@media only screen and (min-width: 1280px) {
+  app-file-picker {
+    display: none;
+  }
+}
+
+@media only screen and (max-width: 1279px) {
+  app-file-dropzone {
+    display: none;
+  }
 }

--- a/src/app/datasets/dataset-detail/dataset-detail.component.scss
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.scss
@@ -25,6 +25,12 @@
   vertical-align: middle;
 }
 
+.attach-card {
+  width: 22em;
+  float: left;
+  margin: 1em;
+}
+
 @media only screen and (min-width: 1280px) {
   app-file-picker {
     display: none;

--- a/src/app/datasets/dataset-table/dataset-table.component.scss
+++ b/src/app/datasets/dataset-table/dataset-table.component.scss
@@ -106,30 +106,30 @@
     flex: 1 0 130px;
     justify-content: center !important;
   }
+}
 
-  :host /deep/ .disabled-row {
-    pointer-events: none;
-    opacity: 0.2 !important;
-  }
+:host /deep/ .disabled-row {
+  pointer-events: none;
+  opacity: 0.2 !important;
+}
 
-  :host /deep/ .mat-row:hover {
-    background-color: rgba(0, 0, 0, 0.1);
-    cursor: pointer;
-  }
+:host /deep/ .mat-row:hover {
+  background-color: rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+}
 
-  :host /deep/ .mat-paginator {
-    background-color: unset !important;
-  }
+:host /deep/ .mat-paginator {
+  background-color: unset !important;
+}
 
-  ::ng-deep mat-header-cell .mat-checkbox-frame {
-    border-color: white;
-  }
+::ng-deep mat-header-cell .mat-checkbox-frame {
+  border-color: white;
+}
 
-  ::ng-deep .tblSettingSelect div.mat-select-arrow-wrapper {
-    display: none;
-  }
+::ng-deep .tblSettingSelect div.mat-select-arrow-wrapper {
+  display: none;
+}
 
-  ::ng-deep .tblSettingSelect.mat-select {
-    display: inline;
-  }
+::ng-deep .tblSettingSelect.mat-select {
+  display: inline;
 }

--- a/src/app/shared/modules/file-uploader/file-dropzone/file-dropzone.component.html
+++ b/src/app/shared/modules/file-uploader/file-dropzone/file-dropzone.component.html
@@ -1,16 +1,43 @@
-<span class="mat-title">Drop a file</span>
+<!-- <span class="mat-title">Drop a file</span> -->
 
 <div
-  ngxFileDropzone
   class="dropzone"
+  ngxFileDropzone
   [readMode]="readMode"
-  (fileDrop)="addFile($event)"
-></div>
+  multiple
+  accept="image/*"
+  (readStart)="onReadStart($event)"
+  (fileDrop)="onFilePicked($event)"
+  (readEnd)="onReadEnd($event)"
+>
+  <div fxLayout="column" style="align-items: center">
+    <div class="instructions">
+      Drop a file here
+    </div>
+    <div class="instructions">or</div>
+    <div class="instructions">
+      <button
+        class="attach-button"
+        type="button"
+        mat-button
+        ngxFilePicker
+        [readMode]="readMode"
+        multiple
+        accept="image/*"
+        (readStart)="onReadStart($event)"
+        (filePick)="onFilePicked($event)"
+        (readEnd)="onReadEnd($event)"
+      >
+        Browse
+      </button>
+    </div>
+  </div>
+</div>
 
-<span class="mat-title" *ngIf="files.length">Dropped files</span>
-<ul>
-  <li *ngFor="let file of files">
-    {{ file.name }} ({{ file.size | filesize }}) read using {{ readMode }}
-    <pre>{{ file.content }}</pre>
-  </li>
-</ul>
+<!-- <span class="mat-title" *ngIf="files.length">Dropped files</span>
+  <ul>
+    <li *ngFor="let file of files">
+      {{ file.name }} ({{ file.size | filesize }}) read using {{ readMode }}
+      <pre>{{ file.content }}</pre>
+    </li>
+  </ul> -->

--- a/src/app/shared/modules/file-uploader/file-dropzone/file-dropzone.component.html
+++ b/src/app/shared/modules/file-uploader/file-dropzone/file-dropzone.component.html
@@ -1,5 +1,3 @@
-<!-- <span class="mat-title">Drop a file</span> -->
-
 <div
   class="dropzone"
   ngxFileDropzone
@@ -33,11 +31,3 @@
     </div>
   </div>
 </div>
-
-<!-- <span class="mat-title" *ngIf="files.length">Dropped files</span>
-  <ul>
-    <li *ngFor="let file of files">
-      {{ file.name }} ({{ file.size | filesize }}) read using {{ readMode }}
-      <pre>{{ file.content }}</pre>
-    </li>
-  </ul> -->

--- a/src/app/shared/modules/file-uploader/file-dropzone/file-dropzone.component.scss
+++ b/src/app/shared/modules/file-uploader/file-dropzone/file-dropzone.component.scss
@@ -1,13 +1,25 @@
 .dropzone {
   align-items: center;
-  background: lightgrey;
+  background: #dcdcdc;
   border: dashed 1px grey;
   display: flex;
   justify-content: center;
   height: 350px;
   width: 500px;
+
+  .instructions {
+    margin: 0.5em;
+    font-size: 1.25em;
+    flex: 1 0 100px;
+    text-align: center;
+  }
+
+  .attach-button {
+    color: #ffffff;
+    background: #0ea432;
+  }
 }
-  
+
 .hover {
   background: grey;
   border: dashed 1px darkgrey;

--- a/src/app/shared/modules/file-uploader/file-dropzone/file-dropzone.component.spec.ts
+++ b/src/app/shared/modules/file-uploader/file-dropzone/file-dropzone.component.spec.ts
@@ -1,18 +1,8 @@
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
-import { ReactiveFormsModule } from "@angular/forms";
-import { ActivatedRoute } from "@angular/router";
-import { Store, StoreModule } from "@ngrx/store";
-import { DatafilesComponent } from "datasets/datafiles/datafiles.component";
-import { MockActivatedRoute, MockStore } from "shared/MockStubs";
-import { rootReducer } from "state-management/reducers/root.reducer";
-import { MatTableModule } from "@angular/material";
+import { Store } from "@ngrx/store";
+import { MockStore } from "shared/MockStubs";
 import { FileDropzoneComponent } from "./file-dropzone.component";
-import * as lb from "shared/sdk/services";
-import { APP_CONFIG } from "app-config.module";
-import { PipesModule } from "shared/pipes/pipes.module";
-
-const mockConfig = {};
 
 describe("FileDropzoneComponent", () => {
   let component: FileDropzoneComponent;
@@ -21,25 +11,11 @@ describe("FileDropzoneComponent", () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
-      imports: [
-        ReactiveFormsModule,
-        MatTableModule,
-        PipesModule,
-        StoreModule.forRoot({ rootReducer })
-      ],
-      declarations: [
-        FileDropzoneComponent,
-        DatafilesComponent
-      ]
+      declarations: [FileDropzoneComponent]
     });
     TestBed.overrideComponent(FileDropzoneComponent, {
       set: {
-        providers: [
-          { provide: ActivatedRoute, useClass: MockActivatedRoute },
-          { provide: APP_CONFIG, useValue: mockConfig },
-          { provide: lb.DatasetAttachmentApi, useValue: mockConfig },
-          { provide: Store, useClass: MockStore }
-        ]
+        providers: [{ provide: Store, useClass: MockStore }]
       }
     });
     TestBed.compileComponents();
@@ -50,7 +26,6 @@ describe("FileDropzoneComponent", () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
-
 
   afterEach(() => {
     fixture.destroy();

--- a/src/app/shared/modules/file-uploader/file-dropzone/file-dropzone.component.ts
+++ b/src/app/shared/modules/file-uploader/file-dropzone/file-dropzone.component.ts
@@ -1,17 +1,77 @@
-import { Component } from "@angular/core";
-import { ReadFile, ReadMode } from "ngx-file-helpers";
+import { Component, OnInit, ViewChild } from "@angular/core";
+import { ReadFile, ReadMode, FilePickerDirective } from "ngx-file-helpers";
+import { Observable } from "rxjs";
+import { Store, select } from "@ngrx/store";
+import { filter } from "rxjs/operators";
+import { Dataset } from "shared/sdk";
+import { AddAttachment } from "state-management/actions/datasets.actions";
 
 @Component({
   selector: "app-file-dropzone",
   templateUrl: "./file-dropzone.component.html",
   styleUrls: ["./file-dropzone.component.scss"]
 })
-export class FileDropzoneComponent {
-  public readMode = ReadMode.dataURL;
-  public isHover: boolean;
-  public files: Array<ReadFile> = [];
+export class FileDropzoneComponent implements OnInit {
+  dataset$: Observable<Dataset>;
+  dataset: any;
+  currentSet$: any;
 
-  addFile(file: ReadFile) {
-    this.files.push(file);
+  public readMode = ReadMode.dataURL;
+  public picked: ReadFile;
+  // public files: Array<ReadFile> = [];
+  public status: string;
+  // public isHover: boolean;
+  @ViewChild(FilePickerDirective, { static: false })
+  private filePicker: FilePickerDirective;
+
+  constructor(private store: Store<any>) {}
+
+  ngOnInit() {
+    this.currentSet$ = this.store.pipe(
+      select(state => state.root.datasets.currentSet)
+    );
+
+    this.dataset$ = this.currentSet$.pipe(
+      filter((dataset: Dataset) => {
+        return dataset && Object.keys(dataset).length > 0;
+      })
+    );
+
+    this.dataset$.subscribe(dataset => {
+      this.dataset = dataset;
+    });
+  }
+
+  // addFile(file: ReadFile) {
+  //   this.files.push(file);
+  // }
+
+  onReadStart(fileCount: number) {
+    this.status = `Now reading ${fileCount} file(s)...`;
+  }
+
+  onFilePicked(file: ReadFile) {
+    this.picked = file;
+  }
+
+  onReadEnd(fileCount: number) {
+    this.status = `Read ${fileCount} file(s) on ${new Date().toLocaleTimeString()}.`;
+    console.log("on readend", this.picked);
+    console.log("on readend", this.dataset);
+    if (fileCount > 0) {
+      const creds = {
+        thumbnail: this.picked.content,
+        caption: "Some caption",
+        creationTime: new Date(),
+        datasetId: this.dataset.pid,
+        rawDatasetId: this.dataset.pid,
+        id: null,
+        dataset: null,
+        derivedDatasetId: this.dataset.pid
+      };
+
+      this.filePicker.reset();
+      return this.store.dispatch(new AddAttachment(creds));
+    }
   }
 }

--- a/src/app/shared/modules/file-uploader/file-dropzone/file-dropzone.component.ts
+++ b/src/app/shared/modules/file-uploader/file-dropzone/file-dropzone.component.ts
@@ -18,9 +18,7 @@ export class FileDropzoneComponent implements OnInit {
 
   public readMode = ReadMode.dataURL;
   public picked: ReadFile;
-  // public files: Array<ReadFile> = [];
   public status: string;
-  // public isHover: boolean;
   @ViewChild(FilePickerDirective, { static: false })
   private filePicker: FilePickerDirective;
 
@@ -41,10 +39,6 @@ export class FileDropzoneComponent implements OnInit {
       this.dataset = dataset;
     });
   }
-
-  // addFile(file: ReadFile) {
-  //   this.files.push(file);
-  // }
 
   onReadStart(fileCount: number) {
     this.status = `Now reading ${fileCount} file(s)...`;

--- a/src/app/shared/modules/file-uploader/file-picker/file-picker.component.html
+++ b/src/app/shared/modules/file-uploader/file-picker/file-picker.component.html
@@ -1,7 +1,5 @@
 <div class="file-chooser">
   <div class="mat-title">Choose an image to upload</div>
-  <!-- <br /> -->
-  <!-- <span>{{ status }}</span> -->
 
   <button
     class="attach-button"

--- a/src/app/shared/modules/file-uploader/file-picker/file-picker.component.html
+++ b/src/app/shared/modules/file-uploader/file-picker/file-picker.component.html
@@ -1,7 +1,7 @@
 <div class="file-chooser">
-  <span class="mat-title">Choose an image to upload</span>
-  <br />
-  <span>{{ status }}</span>
+  <div class="mat-title">Choose an image to upload</div>
+  <!-- <br /> -->
+  <!-- <span>{{ status }}</span> -->
 
   <button
     class="attach-button"

--- a/src/app/shared/modules/file-uploader/file-picker/file-picker.component.scss
+++ b/src/app/shared/modules/file-uploader/file-picker/file-picker.component.scss
@@ -1,14 +1,6 @@
-.attach-button {
-  color: #ffffff;
-  background: #0ea432;
-}
-
-.upload-image {
-  width: 20em;
-  height: 20em;
-}
-
-.upload-card {
-  width: 22em;
-  height: 22em;
+.file-chooser {
+  .attach-button {
+    color: #ffffff;
+    background: #0ea432;
+  }
 }

--- a/src/app/shared/modules/file-uploader/file-picker/file-picker.component.scss
+++ b/src/app/shared/modules/file-uploader/file-picker/file-picker.component.scss
@@ -1,7 +1,3 @@
-.file-chooser {
-
-}
-
 .attach-button {
   color: #ffffff;
   background: #0ea432;

--- a/src/app/shared/modules/file-uploader/file-picker/file-picker.component.spec.ts
+++ b/src/app/shared/modules/file-uploader/file-picker/file-picker.component.spec.ts
@@ -1,18 +1,8 @@
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
-import { ReactiveFormsModule } from "@angular/forms";
-import { ActivatedRoute } from "@angular/router";
-import { Store, StoreModule } from "@ngrx/store";
-import { DatafilesComponent } from "datasets/datafiles/datafiles.component";
-import { MockActivatedRoute, MockStore } from "shared/MockStubs";
-import { rootReducer } from "state-management/reducers/root.reducer";
-import { MatTableModule } from "@angular/material";
+import { Store } from "@ngrx/store";
+import { MockStore } from "shared/MockStubs";
 import { FilePickerComponent } from "./file-picker.component";
-import { APP_CONFIG } from "../../../../app-config.module";
-import * as lb from "shared/sdk/services";
-import { PipesModule } from "shared/pipes/pipes.module";
-
-const mockConfig = {};
 
 describe("FilePickerComponent", () => {
   let component: FilePickerComponent;
@@ -21,30 +11,15 @@ describe("FilePickerComponent", () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
-      imports: [
-        ReactiveFormsModule,
-        MatTableModule,
-        PipesModule,
-        StoreModule.forRoot({ rootReducer })
-      ],
-      declarations: [
-        FilePickerComponent,
-        DatafilesComponent
-      ]
+      declarations: [FilePickerComponent]
     });
     TestBed.overrideComponent(FilePickerComponent, {
       set: {
-        providers: [
-          { provide: ActivatedRoute, useClass: MockActivatedRoute },
-          { provide: APP_CONFIG, useValue: mockConfig },
-          { provide: lb.DatasetAttachmentApi, useValue: mockConfig },
-          { provide: Store, useClass: MockStore }
-        ]
+        providers: [{ provide: Store, useClass: MockStore }]
       }
     });
     TestBed.compileComponents();
   }));
-
 
   afterEach(() => {
     fixture.destroy();

--- a/src/app/shared/modules/file-uploader/file-picker/file-picker.component.ts
+++ b/src/app/shared/modules/file-uploader/file-picker/file-picker.component.ts
@@ -3,7 +3,6 @@ import { select, Store } from "@ngrx/store";
 import { Observable } from "rxjs";
 import { Dataset } from "shared/sdk/models";
 import { APP_CONFIG, AppConfig } from "../../../../app-config.module";
-import * as lb from "shared/sdk/services";
 import { FilePickerDirective, ReadFile, ReadMode } from "ngx-file-helpers";
 import { filter } from "rxjs/operators";
 import { AddAttachment } from "state-management/actions/datasets.actions";
@@ -25,7 +24,6 @@ export class FilePickerComponent implements OnInit, OnDestroy {
 
   constructor(
     @Inject(APP_CONFIG) private config: AppConfig,
-    private daSrv: lb.DatasetAttachmentApi,
     private store: Store<any>
   ) {}
 

--- a/src/app/shared/modules/file-uploader/file-picker/file-picker.component.ts
+++ b/src/app/shared/modules/file-uploader/file-picker/file-picker.component.ts
@@ -1,8 +1,7 @@
-import { Component, Inject, OnDestroy, OnInit, ViewChild } from "@angular/core";
+import { Component, OnInit, ViewChild } from "@angular/core";
 import { select, Store } from "@ngrx/store";
 import { Observable } from "rxjs";
 import { Dataset } from "shared/sdk/models";
-import { APP_CONFIG, AppConfig } from "../../../../app-config.module";
 import { FilePickerDirective, ReadFile, ReadMode } from "ngx-file-helpers";
 import { filter } from "rxjs/operators";
 import { AddAttachment } from "state-management/actions/datasets.actions";
@@ -12,7 +11,7 @@ import { AddAttachment } from "state-management/actions/datasets.actions";
   templateUrl: "./file-picker.component.html",
   styleUrls: ["./file-picker.component.scss"]
 })
-export class FilePickerComponent implements OnInit, OnDestroy {
+export class FilePickerComponent implements OnInit {
   dataset$: Observable<Dataset>;
   dataset: any;
   subscriptions = [];
@@ -22,10 +21,7 @@ export class FilePickerComponent implements OnInit, OnDestroy {
   @ViewChild(FilePickerDirective, { static: false })
   private filePicker: FilePickerDirective;
 
-  constructor(
-    @Inject(APP_CONFIG) private config: AppConfig,
-    private store: Store<any>
-  ) {}
+  constructor(private store: Store<any>) {}
 
   ngOnInit() {
     const currentSet$ = this.store.pipe(
@@ -67,17 +63,6 @@ export class FilePickerComponent implements OnInit, OnDestroy {
 
       this.filePicker.reset();
       return this.store.dispatch(new AddAttachment(creds));
-
-      /*
-      return this.daSrv.create(creds).subscribe(res => {
-        console.log(res);
-        this.filePicker.reset();
-      });
-      */
     }
-  }
-
-  ngOnDestroy() {
-    //    this.subscriptions.forEach(subscription => subscription.unsubscribe());
   }
 }

--- a/src/app/shared/modules/file-uploader/file-uploader.module.ts
+++ b/src/app/shared/modules/file-uploader/file-uploader.module.ts
@@ -4,11 +4,11 @@ import { FileDropzoneComponent } from "./file-dropzone/file-dropzone.component";
 import { FilePickerComponent } from "./file-picker/file-picker.component";
 import { NgxFileHelpersModule } from "ngx-file-helpers";
 import { PipesModule } from "shared/pipes/pipes.module";
-import { MatButtonModule } from "@angular/material";
+import { MatButtonModule, MatCardModule } from "@angular/material";
 
 @NgModule({
   declarations: [FileDropzoneComponent, FilePickerComponent],
-  imports: [CommonModule, MatButtonModule, NgxFileHelpersModule, PipesModule],
+  imports: [CommonModule, MatButtonModule, MatCardModule, NgxFileHelpersModule, PipesModule],
   exports: [FileDropzoneComponent, FilePickerComponent]
 })
 export class FileUploaderModule {}


### PR DESCRIPTION
## Description

Adds the option to upload dataset attachments by drag-and-drop

## Motivation

As a user, I want to be able to upload dataset attachment files through drag-and-drop while using scicat on a computer.

## Changes:

* File-dropzone component now fully functional
* Computer users can now upload dataset attachments through drag-and-drop
* Mobile users can only upload dataset attachments through browse button

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?

