### PR TITLE
Added logic to update attachment caption + show caption in dataset de…

### DIFF
--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -253,7 +253,8 @@
       <div fxFlex="30%" *ngIf="attachments$ | async as attachments">
         <ng-container *ngFor="let da of attachments">
           <mat-card style="margin: 1em">
-            <img mat-card-image src="{{ da.thumbnail }}" /> <br />
+            <img mat-card-image src="{{ da.thumbnail }}" />
+            <p>{{ da.caption }}</p>
           </mat-card>
         </ng-container>
       </div>
@@ -294,7 +295,32 @@
       <mat-card class="attach-card">
         <img src="{{ da.thumbnail }}" style="width: 20em; height: 20em" />
         <mat-card-actions>
-          <button mat-button (click)="delete(dataset.pid, da.id)">
+          <form
+            (submit)="updateCaption(dataset.pid, da.id, caption.value)"
+            action="#"
+          >
+            <mat-form-field>
+              <input
+                matInput
+                id="caption"
+                placeholder="Edit caption"
+                value="{{ da.caption }}"
+                #caption
+              />
+            </mat-form-field>
+            <button
+              mat-button
+              type="submit"
+              style="margin-top: 0.5em; float: right;"
+            >
+              Submit
+            </button>
+          </form>
+          <button
+            mat-button
+            style="float: right"
+            (click)="delete(dataset.pid, da.id)"
+          >
             <mat-icon>delete</mat-icon>
           </button>
         </mat-card-actions>
@@ -321,18 +347,22 @@
         </mat-card-header>
         <div class="details">
           <table>
-              <tr *ngIf="dataset.datasetlifecycle.dateOfPublishing as value">
-                  <th><i class="material-icons"> radio </i> Data Publishing Date</th>
-                  <td>{{ value | date:'yyyy-MM-dd' }}</td>
-              </tr>
-              <tr *ngIf="dataset.datasetlifecycle.dateOfDiskPurging as value">
-                  <th><i class="material-icons"> gavel </i> Data Deletion Date</th>
-                  <td>{{ value | date:'yyyy-MM-dd' }}</td>
-              </tr>
-              <tr *ngIf="dataset.datasetlifecycle.archiveRetentionTime as value">
-                  <th><i class="material-icons"> save </i> Archive Retention Date</th>
-                  <td>{{ value | date: 'yyyy-MM-dd' }}</td>
-              </tr>
+            <tr *ngIf="dataset.datasetlifecycle.dateOfPublishing as value">
+              <th>
+                <i class="material-icons"> radio </i> Data Publishing Date
+              </th>
+              <td>{{ value | date: "yyyy-MM-dd" }}</td>
+            </tr>
+            <tr *ngIf="dataset.datasetlifecycle.dateOfDiskPurging as value">
+              <th><i class="material-icons"> gavel </i> Data Deletion Date</th>
+              <td>{{ value | date: "yyyy-MM-dd" }}</td>
+            </tr>
+            <tr *ngIf="dataset.datasetlifecycle.archiveRetentionTime as value">
+              <th>
+                <i class="material-icons"> save </i> Archive Retention Date
+              </th>
+              <td>{{ value | date: "yyyy-MM-dd" }}</td>
+            </tr>
           </table>
         </div>
       </mat-card>
@@ -359,6 +389,4 @@
       </ng-container>
     </mat-card>
   </mat-tab>
-
-
 </mat-tab-group>

--- a/src/app/datasets/dataset-detail/dataset-detail.component.spec.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.spec.ts
@@ -8,7 +8,7 @@ import { MockActivatedRoute, MockStore } from "shared/MockStubs";
 import { MockRouter } from "shared/MockStubs";
 import { Router } from "@angular/router";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
-import { ReactiveFormsModule } from "@angular/forms";
+import { ReactiveFormsModule, FormsModule } from "@angular/forms";
 import { Store, StoreModule } from "@ngrx/store";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { rootReducer } from "state-management/reducers/root.reducer";
@@ -23,21 +23,18 @@ describe("DatasetDetailComponent", () => {
       schemas: [NO_ERRORS_SCHEMA],
       imports: [
         AppConfigModule,
+        FormsModule,
         ReactiveFormsModule,
         MatTableModule,
         SharedCatanieModule,
         StoreModule.forRoot({ rootReducer })
       ],
-      declarations: [
-        DatasetDetailComponent,
-        DatafilesComponent,
-        LinkyPipe
-      ]
+      declarations: [DatasetDetailComponent, DatafilesComponent, LinkyPipe]
     });
     TestBed.overrideComponent(DatasetDetailComponent, {
       set: {
         providers: [
-          {provide: Router, useClass: MockRouter},
+          { provide: Router, useClass: MockRouter },
           {
             provide: APP_CONFIG,
             useValue: {
@@ -61,7 +58,6 @@ describe("DatasetDetailComponent", () => {
   afterEach(() => {
     fixture.destroy();
   });
-
 
   it("should create", () => {
     expect(component).toBeTruthy();

--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -2,7 +2,8 @@ import { ActivatedRoute } from "@angular/router";
 import { Component, Inject, OnDestroy, OnInit } from "@angular/core";
 import {
   DatablocksAction,
-  DeleteAttachment
+  DeleteAttachment,
+  UpdateAttachmentCaptionAction
 } from "state-management/actions/datasets.actions";
 import { Job, User } from "shared/sdk/models";
 import { select, Store } from "@ngrx/store";
@@ -157,7 +158,6 @@ export class DatasetDetailComponent implements OnInit, OnDestroy {
     }
   }
 
-
   resetDataset(dataset) {
     if (!confirm("Reset datablocks?")) {
       return null;
@@ -187,6 +187,15 @@ export class DatasetDetailComponent implements OnInit, OnDestroy {
         console.log(job);
         this.store.dispatch(new SubmitAction(job));
       });
+  }
+
+  updateCaption(datasetId: string, attachmentId: string, caption: string) {
+    console.log("updateCaption datasetId:", datasetId);
+    console.log("updateCaption attachmentId:", attachmentId);
+    console.log("updateCaption caption:", caption);
+    this.store.dispatch(
+      new UpdateAttachmentCaptionAction(datasetId, attachmentId, caption)
+    );
   }
 
   delete(dataset_id, dataset_attachment_id) {

--- a/src/app/state-management/actions/datasets.actions.spec.ts
+++ b/src/app/state-management/actions/datasets.actions.spec.ts
@@ -24,7 +24,13 @@ import {
   AddAttachment,
   ADD_ATTACHMENT,
   DeleteAttachment,
-  DELETE_ATTACHMENT
+  DELETE_ATTACHMENT,
+  UpdateAttachmentCaptionAction,
+  UPDATE_ATTACHMENT_CAPTION,
+  UpdateAttachmentCaptionCompleteAction,
+  UPDATE_ATTACHMENT_CAPTION_COMPLETE,
+  UpdateAttachmentCaptionFailedAction,
+  UPDATE_ATTACHMENT_CAPTION_FAILED
 } from "./datasets.actions";
 
 describe("UpdateFilterAction", () => {
@@ -124,6 +130,47 @@ describe("DeleteAttachment", () => {
       type: DELETE_ATTACHMENT,
       dataset_id,
       attachment_id
+    });
+  });
+});
+
+describe("UpdateAttachmentCaption", () => {
+  it("should create an action", () => {
+    const datasetId = "123abc";
+    const attachmentId = "abc123";
+    const caption = "New caption";
+    const action = new UpdateAttachmentCaptionAction(
+      datasetId,
+      attachmentId,
+      caption
+    );
+    expect({ ...action }).toEqual({
+      type: UPDATE_ATTACHMENT_CAPTION,
+      datasetId,
+      attachmentId,
+      caption
+    });
+  });
+});
+
+describe("UpdateAttachmentCompleteCaption", () => {
+  it("should create an action", () => {
+    const attachment = new Attachment();
+    const action = new UpdateAttachmentCaptionCompleteAction(attachment);
+    expect({ ...action }).toEqual({
+      type: UPDATE_ATTACHMENT_CAPTION_COMPLETE,
+      attachment
+    });
+  });
+});
+
+describe("UpdateAttachmentFailedCaption", () => {
+  it("should create an action", () => {
+    const error = new Error();
+    const action = new UpdateAttachmentCaptionFailedAction(error);
+    expect({ ...action }).toEqual({
+      type: UPDATE_ATTACHMENT_CAPTION_FAILED,
+      error
     });
   });
 });

--- a/src/app/state-management/actions/datasets.actions.ts
+++ b/src/app/state-management/actions/datasets.actions.ts
@@ -97,17 +97,20 @@ export const REDUCE_DATASET = "[Dataset] Reduce Dataset";
 export const REDUCE_DATASET_COMPLETE = "[Dataset] Reduce Dataset Complete";
 export const REDUCE_DATASET_FAILED = "[Dataset] Reduce Dataset Failed";
 
-export const DELETE_ATTACHMENT = "[DatasetAttachment] Delete Attachment";
+export const DELETE_ATTACHMENT = "[Dataset] Delete Attachment";
 export const DELETE_ATTACHMENT_COMPLETE =
-  "[DatasetAttachment] Delete Attachment Complete";
-export const DELETE_ATTACHMENT_FAILED =
-  "[DatasetAttachment] Delete Attachment Failed";
+  "[Dataset] Delete Attachment Complete";
+export const DELETE_ATTACHMENT_FAILED = "[Dataset] Delete Attachment Failed";
 
-export const ADD_ATTACHMENT = "[DatasetAttachment] Add Attachment";
-export const ADD_ATTACHMENT_COMPLETE =
-  "[DatasetAttachment] Add Attachment Complete";
-export const ADD_ATTACHMENT_FAILED =
-  "[DatasetAttachment] Add Attachment Failed";
+export const ADD_ATTACHMENT = "[Dataset] Add Attachment";
+export const ADD_ATTACHMENT_COMPLETE = "[Dataset] Add Attachment Complete";
+export const ADD_ATTACHMENT_FAILED = "[Dataset] Add Attachment Failed";
+
+export const UPDATE_ATTACHMENT_CAPTION = "[Dataset] Update Attachment Caption";
+export const UPDATE_ATTACHMENT_CAPTION_COMPLETE =
+  "[Dataset] Update Attachment Caption Complete";
+export const UPDATE_ATTACHMENT_CAPTION_FAILED =
+  "[Dataset] Update Attachment Caption Failed";
 
 export class AddAttachment implements Action {
   readonly type = ADD_ATTACHMENT;
@@ -142,6 +145,28 @@ export class DeleteAttachmentFailed implements Action {
   readonly type = DELETE_ATTACHMENT_FAILED;
 
   constructor(readonly attachment_id: string) {}
+}
+
+export class UpdateAttachmentCaptionAction implements Action {
+  readonly type = UPDATE_ATTACHMENT_CAPTION;
+
+  constructor(
+    readonly datasetId: string,
+    readonly attachmentId: string,
+    readonly caption: string
+  ) {}
+}
+
+export class UpdateAttachmentCaptionCompleteAction implements Action {
+  readonly type = UPDATE_ATTACHMENT_CAPTION_COMPLETE;
+
+  constructor(readonly attachment: Attachment) {}
+}
+
+export class UpdateAttachmentCaptionFailedAction implements Action {
+  readonly type = UPDATE_ATTACHMENT_CAPTION_FAILED;
+
+  constructor(readonly error: Error) {}
 }
 
 export class UpdateFilterAction implements Action {
@@ -194,7 +219,6 @@ export class SelectAllDatasetsAction implements Action {
 export class ClearSelectionAction implements Action {
   readonly type = CLEAR_SELECTION;
 }
-
 
 export class ChangePageAction implements Action {
   readonly type = CHANGE_PAGE;

--- a/src/app/state-management/actions/proposals.actions.spec.ts
+++ b/src/app/state-management/actions/proposals.actions.spec.ts
@@ -23,7 +23,13 @@ import {
   AddAttachmentAction,
   ADD_ATTACHMENT,
   DeleteAttachmentAction,
-  DELETE_ATTACHMENT
+  DELETE_ATTACHMENT,
+  UpdateAttachmentCaptionAction,
+  UPDATE_ATTACHMENT_CAPTION,
+  UpdateAttachmentCaptionCompleteAction,
+  UPDATE_ATTACHMENT_CAPTION_COMPLETE,
+  UpdateAttachmentCaptionFailedAction,
+  UPDATE_ATTACHMENT_CAPTION_FAILED
 } from "./proposals.actions";
 
 describe("SelectProposalAction", () => {
@@ -128,6 +134,47 @@ describe("DeleteAttachmentAction", () => {
       type: DELETE_ATTACHMENT,
       proposalId,
       attachmentId
+    });
+  });
+});
+
+describe("UpdateAttachmentCaption", () => {
+  it("should create an action", () => {
+    const proposalId = "123abc";
+    const attachmentId = "abc123";
+    const caption = "New caption";
+    const action = new UpdateAttachmentCaptionAction(
+      proposalId,
+      attachmentId,
+      caption
+    );
+    expect({ ...action }).toEqual({
+      type: UPDATE_ATTACHMENT_CAPTION,
+      proposalId,
+      attachmentId,
+      caption
+    });
+  });
+});
+
+describe("UpdateAttachmentCompleteCaption", () => {
+  it("should create an action", () => {
+    const attachment = new Attachment();
+    const action = new UpdateAttachmentCaptionCompleteAction(attachment);
+    expect({ ...action }).toEqual({
+      type: UPDATE_ATTACHMENT_CAPTION_COMPLETE,
+      attachment
+    });
+  });
+});
+
+describe("UpdateAttachmentFailedCaption", () => {
+  it("should create an action", () => {
+    const error = new Error();
+    const action = new UpdateAttachmentCaptionFailedAction(error);
+    expect({ ...action }).toEqual({
+      type: UPDATE_ATTACHMENT_CAPTION_FAILED,
+      error
     });
   });
 });

--- a/src/app/state-management/actions/proposals.actions.ts
+++ b/src/app/state-management/actions/proposals.actions.ts
@@ -37,6 +37,13 @@ export const DELETE_ATTACHMENT_COMPLETE =
   "[Proposals] Delete Attachment Complete";
 export const DELETE_ATTACHMENT_FAILED = "[Proposals] Delete Attachment Failed";
 
+export const UPDATE_ATTACHMENT_CAPTION =
+  "[Proposals] Update Attachment Caption";
+export const UPDATE_ATTACHMENT_CAPTION_COMPLETE =
+  "[Proposals] Update Attachment Caption Complete";
+export const UPDATE_ATTACHMENT_CAPTION_FAILED =
+  "[Proposals] Update Attachment Caption Failed";
+
 export class SearchProposalAction implements Action {
   type = SEARCH_PROPOSALS;
 
@@ -151,6 +158,28 @@ export class DeleteAttachmentCompleteAction implements Action {
 
 export class DeleteAttachmentFailedAction implements Action {
   readonly type = DELETE_ATTACHMENT_FAILED;
+
+  constructor(readonly error: Error) {}
+}
+
+export class UpdateAttachmentCaptionAction implements Action {
+  readonly type = UPDATE_ATTACHMENT_CAPTION;
+
+  constructor(
+    readonly proposalId: string,
+    readonly attachmentId: string,
+    readonly caption: string
+  ) {}
+}
+
+export class UpdateAttachmentCaptionCompleteAction implements Action {
+  readonly type = UPDATE_ATTACHMENT_CAPTION_COMPLETE;
+
+  constructor(readonly attachment: Attachment) {}
+}
+
+export class UpdateAttachmentCaptionFailedAction implements Action {
+  readonly type = UPDATE_ATTACHMENT_CAPTION_FAILED;
 
   constructor(readonly error: Error) {}
 }

--- a/src/app/state-management/actions/samples.actions.spec.ts
+++ b/src/app/state-management/actions/samples.actions.spec.ts
@@ -8,7 +8,13 @@ import {
   AddAttachmentAction,
   ADD_ATTACHMENT,
   DeleteAttachmentAction,
-  DELETE_ATTACHMENT
+  DELETE_ATTACHMENT,
+  UpdateAttachmentCaptionAction,
+  UPDATE_ATTACHMENT_CAPTION,
+  UpdateAttachmentCaptionCompleteAction,
+  UPDATE_ATTACHMENT_CAPTION_COMPLETE,
+  UpdateAttachmentCaptionFailedAction,
+  UPDATE_ATTACHMENT_CAPTION_FAILED
 } from "./samples.actions";
 import { Attachment, Sample } from "../../shared/sdk/models";
 
@@ -55,6 +61,47 @@ describe("DeleteAttachmentAction", () => {
       type: DELETE_ATTACHMENT,
       sampleId,
       attachmentId
+    });
+  });
+});
+
+describe("UpdateAttachmentCaption", () => {
+  it("should create an action", () => {
+    const sampleId = "123abc";
+    const attachmentId = "abc123";
+    const caption = "New caption";
+    const action = new UpdateAttachmentCaptionAction(
+      sampleId,
+      attachmentId,
+      caption
+    );
+    expect({ ...action }).toEqual({
+      type: UPDATE_ATTACHMENT_CAPTION,
+      sampleId,
+      attachmentId,
+      caption
+    });
+  });
+});
+
+describe("UpdateAttachmentCompleteCaption", () => {
+  it("should create an action", () => {
+    const attachment = new Attachment();
+    const action = new UpdateAttachmentCaptionCompleteAction(attachment);
+    expect({ ...action }).toEqual({
+      type: UPDATE_ATTACHMENT_CAPTION_COMPLETE,
+      attachment
+    });
+  });
+});
+
+describe("UpdateAttachmentFailedCaption", () => {
+  it("should create an action", () => {
+    const error = new Error();
+    const action = new UpdateAttachmentCaptionFailedAction(error);
+    expect({ ...action }).toEqual({
+      type: UPDATE_ATTACHMENT_CAPTION_FAILED,
+      error
     });
   });
 });

--- a/src/app/state-management/actions/samples.actions.ts
+++ b/src/app/state-management/actions/samples.actions.ts
@@ -41,6 +41,12 @@ export const DELETE_ATTACHMENT = "[Sample] Delete Attachment";
 export const DELETE_ATTACHMENT_COMPLETE = "[Sample] Delete Attachment Complete";
 export const DELETE_ATTACHMENT_FAILED = "[Sample] Delete Attachment Failed";
 
+export const UPDATE_ATTACHMENT_CAPTION = "[Sample] Update Attachment Caption";
+export const UPDATE_ATTACHMENT_CAPTION_COMPLETE =
+  "[Sample] Update Attachment Caption Complete";
+export const UPDATE_ATTACHMENT_CAPTION_FAILED =
+  "[Sample] Update Attachment Caption Failed";
+
 export class FetchDatasetsForSample implements Action {
   readonly type = FETCH_DATASETS_FOR_SAMPLE;
 
@@ -180,6 +186,28 @@ export class DeleteAttachmentCompleteAction implements Action {
 
 export class DeleteAttachmentFailedAction implements Action {
   readonly type = DELETE_ATTACHMENT_FAILED;
+
+  constructor(readonly error: Error) {}
+}
+
+export class UpdateAttachmentCaptionAction implements Action {
+  readonly type = UPDATE_ATTACHMENT_CAPTION;
+
+  constructor(
+    readonly sampleId: string,
+    readonly attachmentId: string,
+    readonly caption: string
+  ) {}
+}
+
+export class UpdateAttachmentCaptionCompleteAction implements Action {
+  readonly type = UPDATE_ATTACHMENT_CAPTION_COMPLETE;
+
+  constructor(readonly attachment: Attachment) {}
+}
+
+export class UpdateAttachmentCaptionFailedAction implements Action {
+  readonly type = UPDATE_ATTACHMENT_CAPTION_FAILED;
 
   constructor(readonly error: Error) {}
 }

--- a/src/app/state-management/effects/datasets.effects.ts
+++ b/src/app/state-management/effects/datasets.effects.ts
@@ -82,6 +82,33 @@ export class DatasetEffects {
   );
 
   @Effect()
+  protected updateAttachmentCaption$: Observable<Action> = this.actions$.pipe(
+    ofType(DatasetActions.UPDATE_ATTACHMENT_CAPTION),
+    map((action: DatasetActions.UpdateAttachmentCaptionAction) => action),
+    switchMap(action => {
+      console.log(
+        "Dataset Effects: Updating attachment caption:",
+        action.attachmentId
+      );
+      const newCaption = { caption: action.caption };
+      return this.datasetApi
+        .updateByIdAttachments(
+          encodeURIComponent(action.datasetId),
+          encodeURIComponent(action.attachmentId),
+          newCaption
+        )
+        .pipe(
+          map(
+            res => new DatasetActions.UpdateAttachmentCaptionCompleteAction(res)
+          ),
+          catchError(err =>
+            of(new DatasetActions.UpdateAttachmentCaptionFailedAction(err))
+          )
+        );
+    })
+  );
+
+  @Effect()
   protected getDatablocks$: Observable<Action> = this.actions$.pipe(
     ofType(DatasetActions.DATABLOCKS),
     map((action: DatasetActions.DatablocksAction) => action.id),

--- a/src/app/state-management/effects/proposals.effects.ts
+++ b/src/app/state-management/effects/proposals.effects.ts
@@ -40,7 +40,11 @@ import {
   DeleteAttachmentAction,
   DELETE_ATTACHMENT,
   DeleteAttachmentCompleteAction,
-  DeleteAttachmentFailedAction
+  DeleteAttachmentFailedAction,
+  UPDATE_ATTACHMENT_CAPTION,
+  UpdateAttachmentCaptionAction,
+  UpdateAttachmentCaptionCompleteAction,
+  UpdateAttachmentCaptionFailedAction
 } from "../actions/proposals.actions";
 
 import { getPropFilters } from "state-management/selectors/proposals.selectors";
@@ -168,6 +172,33 @@ export class ProposalsEffects {
         .pipe(
           map(res => new DeleteAttachmentCompleteAction(res)),
           catchError(err => of(new DeleteAttachmentFailedAction(err)))
+        );
+    })
+  );
+
+  @Effect()
+  protected updateAttachmentCaption$: Observable<Action> = this.actions$.pipe(
+    ofType(UPDATE_ATTACHMENT_CAPTION),
+    map((action: UpdateAttachmentCaptionAction) => action),
+    switchMap(action => {
+      console.log(
+        "Proposal Effects: Updating attachment caption:",
+        action.attachmentId
+      );
+      const newCaption = { caption: action.caption };
+      return this.proposalApi
+        .updateByIdAttachments(
+          encodeURIComponent(action.proposalId),
+          encodeURIComponent(action.attachmentId),
+          newCaption
+        )
+        .pipe(
+          map(
+            res => new UpdateAttachmentCaptionCompleteAction(res)
+          ),
+          catchError(err =>
+            of(new UpdateAttachmentCaptionFailedAction(err))
+          )
         );
     })
   );

--- a/src/app/state-management/effects/samples.effects.ts
+++ b/src/app/state-management/effects/samples.effects.ts
@@ -40,7 +40,11 @@ import {
   DELETE_ATTACHMENT,
   DeleteAttachmentAction,
   DeleteAttachmentCompleteAction,
-  DeleteAttachmentFailedAction
+  DeleteAttachmentFailedAction,
+  UPDATE_ATTACHMENT_CAPTION,
+  UpdateAttachmentCaptionAction,
+  UpdateAttachmentCaptionCompleteAction,
+  UpdateAttachmentCaptionFailedAction
 } from "../actions/samples.actions";
 import {
   getQuery,
@@ -178,6 +182,33 @@ export class SamplesEffects {
         .pipe(
           map(res => new DeleteAttachmentCompleteAction(res)),
           catchError(err => of(new DeleteAttachmentFailedAction(err)))
+        );
+    })
+  );
+
+  @Effect()
+  protected updateAttachmentCaption$: Observable<Action> = this.actions$.pipe(
+    ofType(UPDATE_ATTACHMENT_CAPTION),
+    map((action: UpdateAttachmentCaptionAction) => action),
+    switchMap(action => {
+      console.log(
+        "Sample Effects: Updating attachment caption:",
+        action.attachmentId
+      );
+      const newCaption = { caption: action.caption };
+      return this.sampleApi
+        .updateByIdAttachments(
+          encodeURIComponent(action.sampleId),
+          encodeURIComponent(action.attachmentId),
+          newCaption
+        )
+        .pipe(
+          map(
+            res => new UpdateAttachmentCaptionCompleteAction(res)
+          ),
+          catchError(err =>
+            of(new UpdateAttachmentCaptionFailedAction(err))
+          )
         );
     })
   );

--- a/src/app/state-management/reducers/datasets.reducer.ts
+++ b/src/app/state-management/reducers/datasets.reducer.ts
@@ -75,7 +75,10 @@ import {
   REDUCE_DATASET_COMPLETE,
   ReduceDatasetCompleteAction,
   REDUCE_DATASET,
-  REDUCE_DATASET_FAILED
+  REDUCE_DATASET_FAILED,
+  UPDATE_ATTACHMENT_CAPTION_COMPLETE,
+  UpdateAttachmentCaptionCompleteAction,
+  UPDATE_ATTACHMENT_CAPTION_FAILED
 } from "state-management/actions/datasets.actions";
 
 import {
@@ -132,6 +135,28 @@ export function datasetsReducer(
         deletingAttachment: false,
         currentSet: { ...state.currentSet, attachments: attach2 }
       };
+    }
+
+    case UPDATE_ATTACHMENT_CAPTION_COMPLETE: {
+      const updatedAttachment = (action as UpdateAttachmentCaptionCompleteAction)
+        .attachment;
+      const attachments = state.currentSet.attachments;
+      let attach2 = attachments.filter(
+        attachment => attachment.id !== updatedAttachment.id
+      );
+      attach2.push(updatedAttachment);
+
+      return {
+        ...state,
+        currentSet: {
+          ...state.currentSet,
+          attachments: attach2
+        }
+      };
+    }
+
+    case UPDATE_ATTACHMENT_CAPTION_FAILED: {
+      return { ...state };
     }
 
     case SAVE_DATASET: {

--- a/src/app/state-management/reducers/proposals.reducer.ts
+++ b/src/app/state-management/reducers/proposals.reducer.ts
@@ -27,7 +27,10 @@ import {
   DELETE_ATTACHMENT,
   DELETE_ATTACHMENT_COMPLETE,
   DELETE_ATTACHMENT_FAILED,
-  DeleteAttachmentCompleteAction
+  DeleteAttachmentCompleteAction,
+  UPDATE_ATTACHMENT_CAPTION_COMPLETE,
+  UPDATE_ATTACHMENT_CAPTION_FAILED,
+  UpdateAttachmentCaptionCompleteAction
 } from "../actions/proposals.actions";
 import { LOGOUT_COMPLETE, LogoutCompleteAction } from "../actions/user.actions";
 
@@ -140,6 +143,28 @@ export function proposalsReducer(
     }
 
     case DELETE_ATTACHMENT_FAILED: {
+      return { ...state };
+    }
+
+    case UPDATE_ATTACHMENT_CAPTION_COMPLETE: {
+      const updatedAttachment = (action as UpdateAttachmentCaptionCompleteAction)
+        .attachment;
+      const attachments = state.currentProposal.attachments;
+      let attach2 = attachments.filter(
+        attachment => attachment.id !== updatedAttachment.id
+      );
+      attach2.push(updatedAttachment);
+
+      return {
+        ...state,
+        currentProposal: {
+          ...state.currentProposal,
+          attachments: attach2
+        }
+      };
+    }
+
+    case UPDATE_ATTACHMENT_CAPTION_FAILED: {
       return { ...state };
     }
 

--- a/src/app/state-management/reducers/samples.reducer.ts
+++ b/src/app/state-management/reducers/samples.reducer.ts
@@ -37,7 +37,10 @@ import {
   DELETE_ATTACHMENT_COMPLETE,
   DELETE_ATTACHMENT,
   DeleteAttachmentCompleteAction,
-  DELETE_ATTACHMENT_FAILED
+  DELETE_ATTACHMENT_FAILED,
+  UPDATE_ATTACHMENT_CAPTION_COMPLETE,
+  UPDATE_ATTACHMENT_CAPTION_FAILED,
+  UpdateAttachmentCaptionCompleteAction
 } from "state-management/actions/samples.actions";
 import { Action } from "@ngrx/store";
 
@@ -207,6 +210,28 @@ export function samplesReducer(
     }
 
     case DELETE_ATTACHMENT_FAILED: {
+      return { ...state };
+    }
+
+    case UPDATE_ATTACHMENT_CAPTION_COMPLETE: {
+      const updatedAttachment = (action as UpdateAttachmentCaptionCompleteAction)
+        .attachment;
+      const attachments = state.currentSample.attachments;
+      let attach2 = attachments.filter(
+        attachment => attachment.id !== updatedAttachment.id
+      );
+      attach2.push(updatedAttachment);
+
+      return {
+        ...state,
+        currentSample: {
+          ...state.currentSample,
+          attachments: attach2
+        }
+      };
+    }
+
+    case UPDATE_ATTACHMENT_CAPTION_FAILED: {
       return { ...state };
     }
 


### PR DESCRIPTION
…tails

## Description

Added logic to update the caption of an attachment. Dataset details now displays the caption beneath the attachment.

## Motivation

See issue #342 

## Fixes:

* Fixes #342 

## Changes:

* Attachment caption is now displayed beneath the attachment in Dataset details view
* Attachment caption can be edited in the attachments tab in the Dataset detail view
* Added update caption logic to Dataset, Proposal and Sample store

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?

