### PR TITLE
Changed keywords to clickable chips

### DIFF
--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -32,9 +32,22 @@
                 <th><i class="material-icons"> person </i> Owner</th>
                 <td>{{ value }}</td>
               </tr>
-              <tr *ngIf="dataset.keywords as value">
+              <tr *ngIf="dataset.keywords as keywords">
                 <th><i class="material-icons"> vpn_key </i> Keywords</th>
-                <td>{{ value | json }}</td>
+                <td>
+                  <mat-chip-list>
+                    <div *ngIf="keywords.length > 0">
+                      <span *ngFor="let keyword of keywords">
+                        <mat-chip (click)="onClickKeyword(keyword)">
+                          {{ keyword }}
+                        </mat-chip>
+                      </span>
+                    </div>
+                    <div *ngIf="keywords.length === 0">
+                      <mat-chip disabled>No Keywords</mat-chip>
+                    </div>
+                  </mat-chip-list>
+                </td>
               </tr>
               <tr>
                 <th>

--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -3,10 +3,12 @@ import { Component, Inject, OnDestroy, OnInit } from "@angular/core";
 import {
   DatablocksAction,
   DeleteAttachment,
-  UpdateAttachmentCaptionAction
+  UpdateAttachmentCaptionAction,
+  ClearFacetsAction
 } from "state-management/actions/datasets.actions";
 import { Job, User } from "shared/sdk/models";
 import { select, Store } from "@ngrx/store";
+import { AddKeywordFilterAction } from "state-management/actions/datasets.actions";
 import { SubmitAction } from "state-management/actions/jobs.actions";
 import { ShowMessageAction } from "state-management/actions/user.actions";
 import {
@@ -209,5 +211,11 @@ export class DatasetDetailComponent implements OnInit, OnDestroy {
   onClickSample(proposalId: string): void {
     const id = encodeURIComponent(proposalId);
     this.router.navigateByUrl("/samples/" + id);
+  }
+
+  onClickKeyword(keyword: string): void {
+    this.store.dispatch(new ClearFacetsAction());
+    this.store.dispatch(new AddKeywordFilterAction(keyword));
+    this.router.navigateByUrl("/datasets");
   }
 }


### PR DESCRIPTION
## Description

Changed keyword array into clickable chips, linking to filtered datasets table

## Motivation

See issue #445

## Fixes:

* Fixes #445

## Changes:

* Changed keyword array into material chip list
* Clicking on a chip updates datasets filter and navigates to datasets table view

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?

