### PR TITLE
Feature/download small files

### DIFF
--- a/src/app/app-config.module.ts
+++ b/src/app/app-config.module.ts
@@ -18,6 +18,8 @@ export class AppConfig {
   shoppingCartEnabled: boolean;
   multipleDownloadEnabled: boolean;
   multipleDownloadAction?: string;
+  maxDirectDownloadSize: number;
+  sftpHost: string;
   columnSelectEnabled: boolean;
   userProfileImageEnabled: boolean;
   logbookEnabled: boolean;
@@ -46,6 +48,8 @@ export const APP_DI_CONFIG: AppConfig = {
   shoppingCartEnabled: environment["shoppingCartEnabled"] || false,
   multipleDownloadEnabled: environment["multipleDownloadEnabled"] || false,
   multipleDownloadAction: environment["multipleDownloadAction"],
+  maxDirectDownloadSize: environment["maxDirectDownloadSize"] || null,
+  sftpHost: environment["sftpHost"] || null,
   columnSelectEnabled: environment["columnSelectEnabled"] || false,
   userProfileImageEnabled: environment["userProfileImageEnabled"] || false,
   logbookEnabled: environment["logbookEnabled"] || false,

--- a/src/app/datasets/datablocks-table/datablocks-table.component.html
+++ b/src/app/datasets/datablocks-table/datablocks-table.component.html
@@ -1,24 +1,26 @@
-<div>
-  <!-- <h4>{{title}}</h4> -->
-  <mat-table #blockTable [dataSource]="blockSource">
+<mat-table #blockTable [dataSource]="blockSource">
+  <ng-container matColumnDef="id">
+    <mat-header-cell *matHeaderCellDef> ID.</mat-header-cell>
+    <mat-cell *matCellDef="let element"> {{ element.id }}</mat-cell>
+  </ng-container>
 
-    <ng-container matColumnDef="id">
-      <mat-header-cell *matHeaderCellDef> ID.</mat-header-cell>
-      <mat-cell *matCellDef="let element"> {{element.id}}</mat-cell>
-    </ng-container>
+  <ng-container matColumnDef="size">
+    <mat-header-cell *matHeaderCellDef> Size</mat-header-cell>
+    <mat-cell *matCellDef="let element">
+      {{ element.size | filesize }}</mat-cell
+    >
+  </ng-container>
 
-    <ng-container matColumnDef="size">
-      <mat-header-cell *matHeaderCellDef> Size</mat-header-cell>
-      <mat-cell *matCellDef="let element"> {{element.size | filesize}}</mat-cell>
-    </ng-container>
+  <ng-container matColumnDef="files">
+    <mat-header-cell *matHeaderCellDef> Datafiles</mat-header-cell>
+    <mat-cell *matCellDef="let element">
+      {{ element.dataFileList.length }}</mat-cell
+    >
+  </ng-container>
 
-    <ng-container matColumnDef="files">
-      <mat-header-cell *matHeaderCellDef> Datafiles</mat-header-cell>
-      <mat-cell *matCellDef="let element"> {{element.dataFileList.length}}</mat-cell>
-    </ng-container>
-
-    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-    <mat-row (click)="onSelect($event, row)" *matRowDef="let row; columns: displayedColumns;"></mat-row>
-  </mat-table>
-</div>
-
+  <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+  <mat-row
+    (click)="onSelect($event, row)"
+    *matRowDef="let row; columns: displayedColumns"
+  ></mat-row>
+</mat-table>

--- a/src/app/datasets/datablocks-table/datablocks-table.component.spec.ts
+++ b/src/app/datasets/datablocks-table/datablocks-table.component.spec.ts
@@ -1,11 +1,5 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
-
-import { ActivatedRoute, Router } from "@angular/router";
-
 import { MatTableModule } from "@angular/material";
-
-import { MockActivatedRoute, MockRouter } from "shared/MockStubs";
-
 import { DatablocksComponent } from "./datablocks-table.component";
 import { SharedCatanieModule } from "shared/shared.module";
 
@@ -17,14 +11,6 @@ describe("DatablocksComponent", () => {
     TestBed.configureTestingModule({
       imports: [MatTableModule, SharedCatanieModule],
       declarations: [DatablocksComponent]
-    });
-    TestBed.overrideComponent(DatablocksComponent, {
-      set: {
-        providers: [
-          { provide: ActivatedRoute, useClass: MockActivatedRoute },
-          { provide: Router, useClass: MockRouter }
-        ]
-      }
     });
     TestBed.compileComponents();
   }));

--- a/src/app/datasets/datablocks-table/datablocks-table.component.ts
+++ b/src/app/datasets/datablocks-table/datablocks-table.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, OnInit } from "@angular/core";
 import { Datablock } from "shared/sdk/models";
-import { ActivatedRoute, Router } from "@angular/router";
 import { MatTableDataSource } from "@angular/material";
 
 @Component({
@@ -11,17 +10,14 @@ import { MatTableDataSource } from "@angular/material";
 export class DatablocksComponent implements OnInit {
   @Input()
   datablocks: Array<Datablock>;
-  @Input()
-  title = "Datablocks";
 
   blockSource: MatTableDataSource<any> | null;
 
   displayedColumns = ["id", "size", "files"];
 
-  constructor(private router: Router, private route: ActivatedRoute) {}
+  constructor() {}
 
   ngOnInit() {
-    console.log(this.datablocks);
     this.blockSource = new MatTableDataSource(this.datablocks);
   }
 

--- a/src/app/datasets/datafiles/datafiles.component.css
+++ b/src/app/datasets/datafiles/datafiles.component.css
@@ -1,20 +1,19 @@
 .mat-column-select {
-    flex-grow: 0;
-    overflow: visible; /* Needed to prevent offsetting of the checkbox when clicking */
-    padding-right: 1.5em;
-
+  flex-grow: 0;
+  overflow: visible; /* Needed to prevent offsetting of the checkbox when clicking */
+  padding-right: 1.5em;
 }
 
-button[type=submit] {
-    background-color: #0ea432;
-    color: #ffffff;
-    margin-bottom: 1em;
-    float: right;
+.download-button {
+  background-color: #0ea432;
+  color: #ffffff;
+  margin-bottom: 1em;
+  float: right;
 }
 
 .nbr-of-files {
-    float: left;
-    transform: translateY(50%);
-    margin-bottom: 1em;
-    font-size: larger;
+  float: left;
+  transform: translateY(50%);
+  margin-bottom: 1em;
+  font-size: larger;
 }

--- a/src/app/datasets/datafiles/datafiles.component.css
+++ b/src/app/datasets/datafiles/datafiles.component.css
@@ -6,6 +6,8 @@
 }
 
 button[type=submit] {
+    background-color: #0ea432;
+    color: #ffffff;
     margin-bottom: 1em;
     float: right;
 }

--- a/src/app/datasets/datafiles/datafiles.component.html
+++ b/src/app/datasets/datafiles/datafiles.component.html
@@ -1,4 +1,4 @@
-<ng-template [ngIf]="maxFileSize && totalFileSize > maxFileSize">
+<ng-template [ngIf]="maxFileSize && tooLargeFile">
   <span>
     <i class="material-icons" style="color: #ffbe00; vertical-align: middle"
       >warning</i
@@ -28,6 +28,7 @@
     ngNoForm
     method="POST"
     [action]="multipleDownloadAction"
+    target="_blank"
   >
     <input type="hidden" name="jwt" [value]="jwt?.jwt" />
     <input type="hidden" name="base" [value]="dataset.sourceFolder" />
@@ -39,11 +40,11 @@
     />
     <button
       class="download-button"
+      type="submit"
+      mat-flat-button
       [disabled]="
         isNoneSelected || (maxFileSize && selectedFileSize > maxFileSize)
       "
-      type="submit"
-      mat-flat-button
     >
       Download
     </button>

--- a/src/app/datasets/datafiles/datafiles.component.html
+++ b/src/app/datasets/datafiles/datafiles.component.html
@@ -68,7 +68,7 @@
           (change)="onSelectAll($event)"
           [disabled]="
             maxFileSize &&
-            (totalFileSize > maxFileSize || selectedFileSize > maxFileSize)
+            (totalFileSize > maxFileSize || selectedFileSize > maxFileSize || tooLargeFile)
           "
         >
         </mat-checkbox>

--- a/src/app/datasets/datafiles/datafiles.component.html
+++ b/src/app/datasets/datafiles/datafiles.component.html
@@ -1,20 +1,21 @@
-<div *ngIf="maxFileSize && totalFileSize > maxFileSize">
+<ng-template [ngIf]="maxFileSize && totalFileSize > maxFileSize">
   <span>
     <i class="material-icons" style="color: #ffbe00; vertical-align: middle"
       >warning</i
     >
     One or more files are too large to be downloaded directly.
     {{
-      sftpHost && sourceFolder
+      sftpHost
         ? "These files are available via sftp host " +
           sftpHost +
           " in directory " +
-          sourceFolder +
+          dataset.sourceFolder +
           "."
         : ""
     }}
   </span>
-</div>
+</ng-template>
+
 <div class="datafiles-header">
   <span [ngPlural]="count" class="nbr-of-files">
     <ng-template ngPluralCase="=0">No datafiles.</ng-template>
@@ -23,17 +24,13 @@
   </span>
 
   <form
-    *ngIf="multipleDownloadEnabled && multipleDownloadAction && (jwt$ | async)"
+    *ngIf="multipleDownloadEnabled && multipleDownloadAction && jwt"
     ngNoForm
     method="POST"
     [action]="multipleDownloadAction"
   >
-    <input type="hidden" name="jwt" [value]="(jwt$ | async)?.jwt" />
-    <input
-      type="hidden"
-      name="base"
-      [value]="(dataset$ | async).sourceFolder"
-    />
+    <input type="hidden" name="jwt" [value]="jwt?.jwt" />
+    <input type="hidden" name="base" [value]="dataset.sourceFolder" />
     <input
       *ngFor="let file of getSelectedFiles(); index as i"
       type="hidden"
@@ -41,6 +38,7 @@
       [value]="file"
     />
     <button
+      class="download-button"
       [disabled]="
         isNoneSelected || (maxFileSize && selectedFileSize > maxFileSize)
       "
@@ -53,75 +51,70 @@
   <div style="clear: both"></div>
 </div>
 
-<div *ngIf="dataBlocks && dataBlocks.length > 0">
-  <div class="example-container">
-    <mat-table #table [dataSource]="dataSource">
-      <ng-container matColumnDef="select">
-        <mat-header-cell *matHeaderCellDef>
-          <mat-checkbox
-            [checked]="areAllSelected"
-            (change)="onSelectAll($event)"
-            [disabled]="
-              maxFileSize &&
-              (totalFileSize > maxFileSize || selectedFileSize > maxFileSize)
-            "
-          >
-          </mat-checkbox>
-        </mat-header-cell>
-        <mat-cell *matCellDef="let file">
-          <mat-checkbox
-            [name]="file.path"
-            [checked]="file.selected"
-            (change)="onSelect($event, file)"
-            [disabled]="maxFileSize && file.size > maxFileSize"
-          >
-          </mat-checkbox>
-        </mat-cell>
-      </ng-container>
-
-      <ng-container matColumnDef="name">
-        <mat-header-cell *matHeaderCellDef>Path</mat-header-cell>
-        <mat-cell *matCellDef="let file" matTooltip="{{ file.path }}">
-          <a
-            *ngIf="
-              (urlPrefix && file.size <= maxFileSize) ||
-                (urlPrefix && !maxFileSize);
-              else noLink
-            "
-            href="{{ urlPrefix }}/{{ file.path }}"
-          >
-            {{ file.path | filePathTruncate }}
-          </a>
-          <ng-template #noLink>
-            {{ file.path | filePathTruncate }}
-          </ng-template>
-        </mat-cell>
-      </ng-container>
-
-      <ng-container matColumnDef="path">
-        <mat-header-cell *matHeaderCellDef>Time</mat-header-cell>
-        <mat-cell *matCellDef="let file">{{
-          file.time | date: "yyyy-MM-dd HH:mm"
-        }}</mat-cell>
-      </ng-container>
-
-      <ng-container matColumnDef="size">
-        <mat-header-cell *matHeaderCellDef>Size</mat-header-cell>
-        <mat-cell *matCellDef="let file">{{ file.size | filesize }}</mat-cell>
-      </ng-container>
-
-      <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-      <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
-    </mat-table>
-  </div>
-
+<ng-template [ngIf]="datablocks && datablocks.length > 0">
   <mat-paginator
-    [pageSize]="30"
-    [pageSizeOptions]="[10, 30, 50, 100]"
+    [pageSize]="25"
+    [pageSizeOptions]="[10, 25, 50, 100, 500, 1000]"
     [length]="count"
     showFirstLastButtons
   ></mat-paginator>
-</div>
 
-<h4>Original Datablocks</h4>
-<datablocks-table [datablocks]="dataBlocks"></datablocks-table>
+  <mat-table #table [dataSource]="dataSource">
+    <ng-container matColumnDef="select">
+      <mat-header-cell *matHeaderCellDef>
+        <mat-checkbox
+          [checked]="areAllSelected"
+          (change)="onSelectAll($event)"
+          [disabled]="
+            maxFileSize &&
+            (totalFileSize > maxFileSize || selectedFileSize > maxFileSize)
+          "
+        >
+        </mat-checkbox>
+      </mat-header-cell>
+      <mat-cell *matCellDef="let file">
+        <mat-checkbox
+          [name]="file.path"
+          [checked]="file.selected"
+          (change)="onSelect($event, file)"
+          [disabled]="maxFileSize && file.size > maxFileSize"
+        >
+        </mat-checkbox>
+      </mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="name">
+      <mat-header-cell *matHeaderCellDef>Path</mat-header-cell>
+      <mat-cell *matCellDef="let file" matTooltip="{{ file.path }}">
+        <a
+          *ngIf="
+            (urlPrefix && file.size <= maxFileSize) ||
+              (urlPrefix && !maxFileSize);
+            else noLink
+          "
+          href="{{ urlPrefix }}/{{ file.path }}"
+        >
+          {{ file.path | filePathTruncate }}
+        </a>
+        <ng-template #noLink>
+          {{ file.path | filePathTruncate }}
+        </ng-template>
+      </mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="path">
+      <mat-header-cell *matHeaderCellDef>Time</mat-header-cell>
+      <mat-cell *matCellDef="let file">{{
+        file.time | date: "yyyy-MM-dd HH:mm"
+      }}</mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="size">
+      <mat-header-cell *matHeaderCellDef>Size</mat-header-cell>
+      <mat-cell *matCellDef="let file">{{ file.size | filesize }}</mat-cell>
+    </ng-container>
+
+    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+    <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
+  </mat-table>
+</ng-template>

--- a/src/app/datasets/datafiles/datafiles.component.html
+++ b/src/app/datasets/datafiles/datafiles.component.html
@@ -1,3 +1,20 @@
+<div *ngIf="maxFileSize && totalFileSize > maxFileSize">
+  <span>
+    <i class="material-icons" style="color: #ffbe00; vertical-align: middle"
+      >warning</i
+    >
+    One or more files are too large to be downloaded directly.
+    {{
+      sftpHost && sourceFolder
+        ? "These files are available via sftp host " +
+          sftpHost +
+          " in directory " +
+          sourceFolder +
+          "."
+        : ""
+    }}
+  </span>
+</div>
 <div class="datafiles-header">
   <span [ngPlural]="count" class="nbr-of-files">
     <ng-template ngPluralCase="=0">No datafiles.</ng-template>
@@ -5,13 +22,34 @@
     <ng-template ngPluralCase="other">{{ count }} datafiles.</ng-template>
   </span>
 
-  <form *ngIf="multipleDownloadEnabled && multipleDownloadAction && (jwt$ | async)" ngNoForm method="POST" [action]="multipleDownloadAction">
+  <form
+    *ngIf="multipleDownloadEnabled && multipleDownloadAction && (jwt$ | async)"
+    ngNoForm
+    method="POST"
+    [action]="multipleDownloadAction"
+  >
     <input type="hidden" name="jwt" [value]="(jwt$ | async)?.jwt" />
-    <input type="hidden" name="base" [value]="(dataset$ | async).sourceFolder" />
-    <input *ngFor="let file of getSelectedFiles(); index as i" type="hidden" [name]="'files[' + i + ']'" [value]="file" />
-    <button [disabled]="isNoneSelected" type="submit" mat-flat-button>Download</button>
+    <input
+      type="hidden"
+      name="base"
+      [value]="(dataset$ | async).sourceFolder"
+    />
+    <input
+      *ngFor="let file of getSelectedFiles(); index as i"
+      type="hidden"
+      [name]="'files[' + i + ']'"
+      [value]="file"
+    />
+    <button
+      [disabled]="
+        isNoneSelected || (maxFileSize && selectedFileSize > maxFileSize)
+      "
+      type="submit"
+      mat-flat-button
+    >
+      Download
+    </button>
   </form>
-
   <div style="clear: both"></div>
 </div>
 
@@ -20,43 +58,69 @@
     <mat-table #table [dataSource]="dataSource">
       <ng-container matColumnDef="select">
         <mat-header-cell *matHeaderCellDef>
-          <mat-checkbox [checked]="areAllSelected" (change)="onSelectAll($event)">
+          <mat-checkbox
+            [checked]="areAllSelected"
+            (change)="onSelectAll($event)"
+            [disabled]="
+              maxFileSize &&
+              (totalFileSize > maxFileSize || selectedFileSize > maxFileSize)
+            "
+          >
           </mat-checkbox>
         </mat-header-cell>
         <mat-cell *matCellDef="let file">
-          <mat-checkbox [name]="file.path" [checked]="file.selected" (change)="onSelect($event, file)">
+          <mat-checkbox
+            [name]="file.path"
+            [checked]="file.selected"
+            (change)="onSelect($event, file)"
+            [disabled]="maxFileSize && file.size > maxFileSize"
+          >
           </mat-checkbox>
         </mat-cell>
       </ng-container>
 
       <ng-container matColumnDef="name">
         <mat-header-cell *matHeaderCellDef>Path</mat-header-cell>
-        <mat-cell *matCellDef="let file" matTooltip="{{file.path}}">
-          <a *ngIf="urlPrefix; else noLink" href="{{urlPrefix}}{{file.path}}">
-            {{file.path | filePathTruncate }}
+        <mat-cell *matCellDef="let file" matTooltip="{{ file.path }}">
+          <a
+            *ngIf="
+              (urlPrefix && file.size <= maxFileSize) ||
+                (urlPrefix && !maxFileSize);
+              else noLink
+            "
+            href="{{ urlPrefix }}/{{ file.path }}"
+          >
+            {{ file.path | filePathTruncate }}
           </a>
           <ng-template #noLink>
-            {{file.path}}
+            {{ file.path | filePathTruncate }}
           </ng-template>
         </mat-cell>
       </ng-container>
 
       <ng-container matColumnDef="path">
         <mat-header-cell *matHeaderCellDef>Time</mat-header-cell>
-        <mat-cell *matCellDef="let file">{{file.time | date: 'yyyy-MM-dd HH:mm'}}</mat-cell>
+        <mat-cell *matCellDef="let file">{{
+          file.time | date: "yyyy-MM-dd HH:mm"
+        }}</mat-cell>
       </ng-container>
 
       <ng-container matColumnDef="size">
         <mat-header-cell *matHeaderCellDef>Size</mat-header-cell>
-        <mat-cell *matCellDef="let file">{{file.size | filesize}}</mat-cell>
+        <mat-cell *matCellDef="let file">{{ file.size | filesize }}</mat-cell>
       </ng-container>
 
       <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-      <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+      <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
     </mat-table>
   </div>
 
-  <mat-paginator [pageSize]="30" [pageSizeOptions]="[10,30, 50, 100]" [length]="count" showFirstLastButtons></mat-paginator>
+  <mat-paginator
+    [pageSize]="30"
+    [pageSizeOptions]="[10, 30, 50, 100]"
+    [length]="count"
+    showFirstLastButtons
+  ></mat-paginator>
 </div>
 
 <h4>Original Datablocks</h4>

--- a/src/app/datasets/datafiles/datafiles.component.spec.ts
+++ b/src/app/datasets/datafiles/datafiles.component.spec.ts
@@ -3,12 +3,9 @@ import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { ReactiveFormsModule } from "@angular/forms";
 import { DatafilesComponent } from "./datafiles.component";
 import { MatTableModule } from "@angular/material";
-import { Store } from "@ngrx/store";
-import { MockStore, MockUserApi } from "shared/MockStubs";
 import { AppConfigModule } from "app-config.module";
-import { FileSizePipe } from "../../shared/pipes/filesize.pipe";
 import { OrigDatablock } from "shared/sdk";
-import { FilePathTruncate } from "shared/pipes/file-path-truncate.pipe";
+import { PipesModule } from "shared/pipes/pipes.module";
 
 describe("DatafilesComponent", () => {
   let component: DatafilesComponent;
@@ -19,13 +16,13 @@ describe("DatafilesComponent", () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
-      imports: [ReactiveFormsModule, MatTableModule, AppConfigModule],
-      declarations: [DatafilesComponent, FileSizePipe, FilePathTruncate]
-    });
-    TestBed.overrideComponent(DatafilesComponent, {
-      set: {
-        providers: [{ provide: Store, useClass: MockStore }]
-      }
+      imports: [
+        ReactiveFormsModule,
+        MatTableModule,
+        AppConfigModule,
+        PipesModule
+      ],
+      declarations: [DatafilesComponent]
     });
     TestBed.compileComponents();
   }));

--- a/src/app/datasets/datafiles/datafiles.component.spec.ts
+++ b/src/app/datasets/datafiles/datafiles.component.spec.ts
@@ -269,6 +269,32 @@ describe("DatafilesComponent", () => {
     });
   });
 
+  describe("#hasTooLargeFiles()", () => {
+    it("should return false if maxFileSize is undefined", () => {
+      component.getDatafiles(datablocks);
+      component.maxFileSize = null;
+      const tooLargeFile = component.hasTooLargeFiles(component.files);
+
+      expect(tooLargeFile).toEqual(false);
+    });
+
+    it("should return false if all files are smaller than maxFileSize", () => {
+      component.getDatafiles(datablocks);
+      component.maxFileSize = 20000;
+      const tooLargeFile = component.hasTooLargeFiles(component.files);
+
+      expect(tooLargeFile).toEqual(false);
+    });
+
+    it("should return true if one or more files are larger than maxFileSize", () => {
+      component.getDatafiles(datablocks);
+      component.maxFileSize = 10;
+      const tooLargeFile = component.hasTooLargeFiles(component.files);
+
+      expect(tooLargeFile).toEqual(true);
+    });
+  });
+
   describe("onDownload()", () => {
     xit("should ...", () => {});
   });

--- a/src/app/datasets/datafiles/datafiles.component.spec.ts
+++ b/src/app/datasets/datafiles/datafiles.component.spec.ts
@@ -7,12 +7,14 @@ import { Store } from "@ngrx/store";
 import { MockStore, MockUserApi } from "shared/MockStubs";
 import { AppConfigModule } from "app-config.module";
 import { FileSizePipe } from "../../shared/pipes/filesize.pipe";
-import { UserApi } from "shared/sdk";
+import { OrigDatablock } from "shared/sdk";
 import { FilePathTruncate } from "shared/pipes/file-path-truncate.pipe";
 
 describe("DatafilesComponent", () => {
   let component: DatafilesComponent;
   let fixture: ComponentFixture<DatafilesComponent>;
+
+  let datablocks: OrigDatablock[];
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -22,10 +24,7 @@ describe("DatafilesComponent", () => {
     });
     TestBed.overrideComponent(DatafilesComponent, {
       set: {
-        providers: [
-          { provide: Store, useClass: MockStore },
-          { provide: UserApi, useClass: MockUserApi }
-        ]
+        providers: [{ provide: Store, useClass: MockStore }]
       }
     });
     TestBed.compileComponents();
@@ -37,12 +36,240 @@ describe("DatafilesComponent", () => {
     fixture.detectChanges();
   });
 
-
   afterEach(() => {
     fixture.destroy();
   });
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  beforeEach(() => {
+    datablocks = [new OrigDatablock()];
+    datablocks[0].dataFileList = [
+      {
+        path: "test1",
+        size: 5000,
+        time: "2019-09-06T13:11:37.102Z",
+        chk: "string",
+        uid: "string",
+        gid: "string",
+        perm: "string"
+      },
+      {
+        path: "test2",
+        size: 10000,
+        time: "2019-09-06T13:11:37.102Z",
+        chk: "string",
+        uid: "string",
+        gid: "string",
+        perm: "string"
+      }
+    ];
+  });
+
+  describe("#getDataFiles()", () => {
+    it("should add an array of files, with added property 'selected' set to 'false', to dataSource", () => {
+      expect(component.dataSource.data.length).toEqual(0);
+
+      component.getDatafiles(datablocks);
+
+      expect(component.dataSource.data.length).toEqual(2);
+      component.dataSource.data.forEach(file => {
+        expect(Object.keys(file)).toContain("selected");
+        expect(file["selected"]).toEqual(false);
+      });
+    });
+  });
+
+  describe("#getAreAllSelected()", () => {
+    it("should return 'false' if no file is selected", () => {
+      component.getDatafiles(datablocks);
+      const areAllSelected = component.getAreAllSelected();
+
+      expect(areAllSelected).toEqual(false);
+    });
+
+    it("should return 'false' if only some files are selected", () => {
+      component.getDatafiles(datablocks);
+      component.dataSource.data[0].selected = true;
+      const areAllSelected = component.getAreAllSelected();
+
+      expect(areAllSelected).toEqual(false);
+    });
+
+    it("should return 'true' if all files are selected", () => {
+      component.getDatafiles(datablocks);
+      component.dataSource.data.forEach(file => {
+        file.selected = true;
+      });
+      const areAllSelected = component.getAreAllSelected();
+
+      expect(areAllSelected).toEqual(true);
+    });
+  });
+
+  describe("#getIsNoneSelected()", () => {
+    it("should return 'true' if no file is selected", () => {
+      component.getDatafiles(datablocks);
+      const isNoneSelected = component.getIsNoneSelected();
+
+      expect(isNoneSelected).toEqual(true);
+    });
+
+    it("should return 'false' if some files are selected", () => {
+      component.getDatafiles(datablocks);
+      component.dataSource.data[0].selected = true;
+      const isNoneSelected = component.getIsNoneSelected();
+
+      expect(isNoneSelected).toEqual(false);
+    });
+
+    it("should return 'false' if all files are selected", () => {
+      component.getDatafiles(datablocks);
+      component.dataSource.data.forEach(file => {
+        file.selected = true;
+      });
+      const isNoneSelected = component.getIsNoneSelected();
+
+      expect(isNoneSelected).toEqual(false);
+    });
+  });
+
+  describe("getSelectedFiles()", () => {
+    it("should return an empty array if dataSource is undefined", () => {
+      component.dataSource = undefined;
+      const selectedFiles = component.getSelectedFiles();
+
+      expect(selectedFiles.length).toEqual(0);
+    });
+
+    it("should return an empty array if no files are selected", () => {
+      component.getDatafiles(datablocks);
+      const selectedFiles = component.getSelectedFiles();
+
+      expect(selectedFiles.length).toEqual(0);
+    });
+
+    it("should return an array of file paths if some files are selected", () => {
+      component.getDatafiles(datablocks);
+      component.dataSource.data[0].selected = true;
+      const selectedFiles = component.getSelectedFiles();
+
+      expect(selectedFiles.length).toEqual(1);
+      expect(selectedFiles).toContain("test1");
+    });
+  });
+
+  describe("#updateSelectionStatus()", () => {
+    it("should set 'areAllSelected' to false and 'isNoneSelected' to true if no file is selected", () => {
+      component.getDatafiles(datablocks);
+      component.updateSelectionStatus();
+
+      expect(component.areAllSelected).toEqual(false);
+      expect(component.isNoneSelected).toEqual(true);
+    });
+
+    it("should set both 'areAllSelected' and 'isNoneSelected' to false if some files are selected", () => {
+      component.getDatafiles(datablocks);
+      component.dataSource.data[0].selected = true;
+      component.updateSelectionStatus();
+
+      expect(component.areAllSelected).toEqual(false);
+      expect(component.isNoneSelected).toEqual(false);
+    });
+
+    it("should set 'areAllSelected' to true and 'isNoneSelected' to false if all files are selected", () => {
+      component.getDatafiles(datablocks);
+      component.dataSource.data.forEach(file => {
+        file.selected = true;
+      });
+      component.updateSelectionStatus();
+
+      expect(component.areAllSelected).toEqual(true);
+      expect(component.isNoneSelected).toEqual(false);
+    });
+  });
+
+  describe("#onSelect()", () => {
+    it("should set 'selected' of the provided file to true if previously set to false and add the size of the file to 'selectedFileSize'", () => {
+      component.getDatafiles(datablocks);
+      const event = {
+        checked: true
+      };
+      const file = component.dataSource.data[0];
+      component.onSelect(event, file);
+
+      expect(component.dataSource.data[0].selected).toEqual(true);
+      expect(component.selectedFileSize).toEqual(file.size);
+    });
+
+    it("should set 'selected' of the provided file to false if previously set to true and subtract the size of the file from 'selectedFileSize'", () => {
+      component.getDatafiles(datablocks);
+      const firstEvent = {
+        checked: true
+      };
+      const firstFile = component.dataSource.data[0];
+      component.onSelect(firstEvent, firstFile);
+
+      expect(component.dataSource.data[0].selected).toEqual(true);
+      expect(component.selectedFileSize).toEqual(firstFile.size);
+
+      const secondEvent = {
+        checked: false
+      };
+      const secondFile = component.dataSource.data[0];
+      component.onSelect(secondEvent, secondFile);
+
+      expect(component.dataSource.data[0].selected).toEqual(false);
+      expect(component.selectedFileSize).toEqual(0);
+    });
+  });
+
+  describe("#onSelectAll()", () => {
+    it("should set 'selected' of all files to true if previously set to false and add the size of the files to 'selectedFileSize'", () => {
+      component.getDatafiles(datablocks);
+
+      const event = {
+        checked: true
+      };
+      component.onSelectAll(event);
+
+      component.dataSource.data.forEach(file => {
+        expect(file.selected).toEqual(true);
+      });
+
+      expect(component.selectedFileSize).toEqual(15000);
+    });
+
+    it("should set 'selected' of all files to false if previously set to true and subtract the size of the files from 'selectedFileSize'", () => {
+      component.getDatafiles(datablocks);
+
+      const firstEvent = {
+        checked: true
+      };
+      component.onSelectAll(firstEvent);
+
+      component.dataSource.data.forEach(file => {
+        expect(file.selected).toEqual(true);
+      });
+
+      expect(component.selectedFileSize).toEqual(15000);
+
+      const secondEvent = {
+        checked: false
+      };
+      component.onSelectAll(secondEvent);
+
+      component.dataSource.data.forEach(file => {
+        expect(file.selected).toEqual(false);
+      });
+
+      expect(component.selectedFileSize).toEqual(0);
+    });
+  });
+
+  describe("onDownload()", () => {
+    xit("should ...", () => {});
   });
 });

--- a/src/app/datasets/datafiles/datafiles.component.ts
+++ b/src/app/datasets/datafiles/datafiles.component.ts
@@ -28,7 +28,8 @@ export class DatafilesComponent
   jwt: any;
 
   count = 0;
-  files: Array<JSON> = [];
+  files: Array<any> = [];
+  tooLargeFile: boolean;
   totalFileSize: number = 0;
   selectedFileSize: number = 0;
 
@@ -81,6 +82,7 @@ export class DatafilesComponent
       });
       this.files = this.files.concat(selectable);
     });
+    this.tooLargeFile = this.hasTooLargeFiles(this.files);
     this.dataSource.data = this.files;
   }
 
@@ -132,6 +134,21 @@ export class DatafilesComponent
       }
     }
     this.updateSelectionStatus();
+  }
+
+  hasTooLargeFiles(files: any[]) {
+    if (this.maxFileSize) {
+      const largeFiles = files.filter(file => {
+        return file.size > this.maxFileSize;
+      });
+      if (largeFiles.length > 0) {
+        return true;
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
   }
 
   // onDownload() {

--- a/src/app/datasets/datafiles/datafiles.component.ts
+++ b/src/app/datasets/datafiles/datafiles.component.ts
@@ -23,9 +23,13 @@ import { UserApi } from "shared/sdk/services";
   providers: [UserApi],
   styleUrls: ["./datafiles.component.css"]
 })
-export class DatafilesComponent implements OnInit, AfterViewInit, AfterViewChecked {
+export class DatafilesComponent
+  implements OnInit, AfterViewInit, AfterViewChecked {
   @Input()
   dataBlocks: Array<OrigDatablock>;
+
+  @Input()
+  sourceFolder: string;
 
   urlPrefix: string;
   count = 0;
@@ -34,11 +38,20 @@ export class DatafilesComponent implements OnInit, AfterViewInit, AfterViewCheck
   dsId: string;
   dataFiles: Array<any> = [];
 
+  totalFileSize: number = 0;
+  selectedFileSize: number = 0;
+
   areAllSelected = false;
   isNoneSelected = true;
 
   multipleDownloadEnabled: boolean = this.appConfig.multipleDownloadEnabled;
   multipleDownloadAction: string = this.appConfig.multipleDownloadAction;
+  maxFileSize: number = this.appConfig.maxDirectDownloadSize;
+  sftpHost: string = this.appConfig.sftpHost;
+  sftpInfo: string =
+    this.sftpHost && this.sourceFolder
+      ? `These files are available via sftp host "${this.sftpHost}" in directory "${this.sourceFolder}".`
+      : "";
 
   displayedColumns = (this.appConfig.multipleDownloadEnabled
     ? ["select"]
@@ -90,6 +103,7 @@ export class DatafilesComponent implements OnInit, AfterViewInit, AfterViewCheck
     datablocks.forEach(block => {
       const files = block.dataFileList;
       const selectable = files.map(file => {
+        this.totalFileSize += file.size;
         return { ...file, selected: false };
       });
       this.files = this.files.concat(selectable);
@@ -128,6 +142,11 @@ export class DatafilesComponent implements OnInit, AfterViewInit, AfterViewCheck
   onSelect(event, file) {
     file.selected = event.checked;
     this.updateSelectionStatus();
+    if (event.checked) {
+      this.selectedFileSize += file.size;
+    } else {
+      this.selectedFileSize -= file.size;
+    }
   }
 
   onSelectAll(event) {

--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -264,7 +264,10 @@
       <i class="material-icons"> cloud_download </i> Datafiles
     </ng-template>
     <mat-card style="margin: 1em">
-      <datafiles [dataBlocks]="origDatablocks$ | async"></datafiles>
+      <datafiles
+        [dataBlocks]="origDatablocks$ | async"
+        [sourceFolder]="(dataset$ | async).sourceFolder"
+      ></datafiles>
       <div *ngIf="(origDatablocks$ | async).length === 0">
         <h3>No datafiles linked to this dataset</h3>
       </div>

--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -265,9 +265,16 @@
     </ng-template>
     <mat-card style="margin: 1em">
       <datafiles
-        [dataBlocks]="origDatablocks$ | async"
-        [sourceFolder]="(dataset$ | async).sourceFolder"
+        [datablocks]="origDatablocks$ | async"
+        [dataset]="dataset$ | async"
+        [jwt]="jwt$ | async"
       ></datafiles>
+      <div class="datablocks-table">
+        <h4>Original Datablocks</h4>
+        <datablocks-table
+          [datablocks]="origDatablocks$ | async"
+        ></datablocks-table>
+      </div>
       <div *ngIf="(origDatablocks$ | async).length === 0">
         <h3>No datafiles linked to this dataset</h3>
       </div>

--- a/src/app/datasets/dataset-detail/dataset-detail.component.scss
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.scss
@@ -25,6 +25,10 @@
   vertical-align: middle;
 }
 
+.datablocks-table {
+  margin-top: 5em;
+}
+
 .attach-card {
   width: 22em;
   float: left;

--- a/src/app/datasets/dataset-detail/dataset-detail.component.spec.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.spec.ts
@@ -4,7 +4,7 @@ import { DatafilesComponent } from "datasets/datafiles/datafiles.component";
 import { DatasetDetailComponent } from "./dataset-detail.component";
 import { LinkyPipe } from "ngx-linky";
 import { MatTableModule } from "@angular/material";
-import { MockActivatedRoute, MockStore } from "shared/MockStubs";
+import { MockActivatedRoute, MockStore, MockUserApi } from "shared/MockStubs";
 import { Router } from "@angular/router";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ReactiveFormsModule, FormsModule } from "@angular/forms";
@@ -23,7 +23,7 @@ import {
   DeleteAttachment,
   UpdateAttachmentCaptionAction
 } from "state-management/actions/datasets.actions";
-import { Dataset } from "shared/sdk";
+import { Dataset, UserApi } from "shared/sdk";
 
 describe("DatasetDetailComponent", () => {
   let component: DatasetDetailComponent;
@@ -59,7 +59,8 @@ describe("DatasetDetailComponent", () => {
               editMetadataEnabled: true
             }
           },
-          { provide: ActivatedRoute, useClass: MockActivatedRoute }
+          { provide: ActivatedRoute, useClass: MockActivatedRoute },
+          { provide: UserApi, useClass: MockUserApi }
         ]
       }
     });

--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -15,7 +15,7 @@ import {
   getError,
   submitJob
 } from "../../state-management/selectors/jobs.selectors";
-import { Subscription } from "rxjs";
+import { Subscription, Observable } from "rxjs";
 import { Message, MessageType } from "state-management/models";
 import { getIsAdmin } from "state-management/selectors/users.selectors";
 import { APP_CONFIG, AppConfig } from "app-config.module";
@@ -28,6 +28,7 @@ import {
   getCurrentOrigDatablocks,
   getCurrentDatasetWithoutOrigData
 } from "state-management/selectors/datasets.selectors";
+import { UserApi } from "shared/sdk";
 
 /**
  * Component to show details for a data set, using the
@@ -44,6 +45,7 @@ import {
 export class DatasetDetailComponent implements OnInit, OnDestroy {
   dataset$ = this.store.pipe(select(getCurrentDataset));
   datasetwithout$ = this.store.pipe(select(getCurrentDatasetWithoutOrigData));
+  jwt$: Observable<any>;
 
   private subscriptions: Subscription[] = [];
   private routeSubscription = this.route.params
@@ -58,6 +60,7 @@ export class DatasetDetailComponent implements OnInit, OnDestroy {
     private router: Router,
     private route: ActivatedRoute,
     private store: Store<any>,
+    private userApi: UserApi,
     @Inject(APP_CONFIG) public appConfig: AppConfig
   ) {}
 
@@ -89,6 +92,8 @@ export class DatasetDetailComponent implements OnInit, OnDestroy {
         }
       })
     );
+
+    this.jwt$ = this.userApi.jwt();
   }
 
   ngOnDestroy() {

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -21,6 +21,7 @@ export const environment = {
   logbookEnabled: true,
   metadataPreviewEnabled: true,
   multipleDownloadEnabled: true,
+  maxDirectDownloadSize: 1000,
   multipleDownloadAction: "http://localhost:3011/zip",
   scienceSearchEnabled: true,
   searchProposals: true,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -21,7 +21,7 @@ export const environment = {
   logbookEnabled: true,
   metadataPreviewEnabled: true,
   multipleDownloadEnabled: true,
-  maxDirectDownloadSize: 1000,
+  maxDirectDownloadSize: 5000000000,
   multipleDownloadAction: "http://localhost:3011/zip",
   scienceSearchEnabled: true,
   searchProposals: true,


### PR DESCRIPTION
## Description

Stops users from directly downloading files larger than a maximum file size set in the environment file.

## Motivation

As a user, I should be able to download small files directly.

## Changes:

* Added a maxDirectDownloadSize and sftpHost to environment
* Removes download url for files larger than maximum file size
* Files larger than maximum file size cannot be added to multiple download
* Disables select-all checkbox if one or more files are too large for direct donwload
* Warning message appears if one or more files are too large to download directly
* If sftpHost is configured, the warning message also tells the user where files can be downloaded

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?

