### PR TITLE
Made app header responsive

### DIFF
--- a/src/app/_layout/app-header/app-header.component.html
+++ b/src/app/_layout/app-header/app-header.component.html
@@ -1,4 +1,5 @@
 <div
+  class="header"
   [class.dark-theme]="darkTheme$ | async"
   [class.light-theme]="!(darkTheme$ | async)"
 >
@@ -78,7 +79,7 @@
         <h6>
           <a class="toplink" [routerLink]="['/help']">
             <i class="material-icons"> help </i>
-            Help</a
+            <span class="large-screen-text">Help</span></a
           >
         </h6>
       </div>
@@ -86,7 +87,7 @@
         <h6>
           <a class="toplink" [routerLink]="['/about']">
             <i class="material-icons"> info </i>
-            About</a
+            <span class="large-screen-text">About</span></a
           >
         </h6>
       </div>
@@ -97,7 +98,7 @@
             src="{{ profileImage }}"
             style="height: 37px"
           />
-          <div>{{ username }}</div>
+          <div class="large-screen-text">{{ username }}</div>
         </button>
       </div>
     </mat-toolbar-row>

--- a/src/app/_layout/app-header/app-header.component.scss
+++ b/src/app/_layout/app-header/app-header.component.scss
@@ -1,43 +1,54 @@
 @import "src/theme.scss";
 
-mat-toolbar {
+.header {
   position: sticky;
+  position: -webkit-sticky;
+  top: 0;
+  z-index: 1000;
 
-  height: 5vh;
+  mat-toolbar {
+    height: 5vh;
 
-  a {
-    color: mat-color($primary);
+    a {
+      color: mat-color($primary);
+    }
+
+    a:hover {
+      color: mat-color($accent);
+    }
+
+    .material-icons {
+      vertical-align: middle;
+    }
+
+    .app-title {
+      margin-left: 2%;
+    }
+
+    .example-spacer {
+      flex: 1 1 auto;
+    }
+
+    .toplink {
+      color: #ffffff;
+      padding: 10px;
+      font: bold;
+      font-size: 11pt;
+      font-family: "Times New Roman", Times, serif;
+    }
+
+    .userButton {
+      margin-top: 3px;
+      background-color: transparent;
+      border: none;
+      font-size: 10px;
+      line-height: 20px;
+    }
   }
+}
 
-  a:hover {
-    color: mat-color($accent);
-  }
-
-  .material-icons {
-    vertical-align: middle;
-  }
-
-  .app-title {
-    margin-left: 2%;
-  }
-
-  .example-spacer {
-    flex: 1 1 auto;
-  }
-
-  .toplink {
-    color: #ffffff;
-    padding: 10px;
-    font: bold;
-    font-size: 11pt;
-    font-family: "Times New Roman", Times, serif;
-  }
-
-  .userButton {
-    margin-top: 3px;
-    background-color: transparent;
-    border: none;
-    font-size: 10px;
-    line-height: 20px;
+@media only screen and (max-width: 1279px) {
+  .large-screen-text {
+    display: none;
   }
 }

--- a/src/app/_layout/app-header/app-header.component.spec.ts
+++ b/src/app/_layout/app-header/app-header.component.spec.ts
@@ -1,28 +1,41 @@
-import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import {
+  async,
+  ComponentFixture,
+  TestBed,
+  inject
+} from "@angular/core/testing";
 
 import { AppHeaderComponent } from "./app-header.component";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { MatMenuModule, MatToolbarModule } from "@angular/material";
 import { LoginService } from "users/login.service";
 import { MockLoginService, MockStore } from "shared/MockStubs";
-import { Store } from "@ngrx/store";
+import { Store, StoreModule } from "@ngrx/store";
 import { APP_CONFIG } from "app-config.module";
+import { rootReducer } from "state-management/reducers/root.reducer";
+import { LogoutAction } from "state-management/actions/user.actions";
 
 describe("AppHeaderComponent", () => {
   let component: AppHeaderComponent;
   let fixture: ComponentFixture<AppHeaderComponent>;
 
+  let store: MockStore;
+  let dispatchSpy;
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
       declarations: [AppHeaderComponent],
-      imports: [MatMenuModule, MatToolbarModule]
+      imports: [
+        MatMenuModule,
+        MatToolbarModule,
+        StoreModule.forRoot({ rootReducer })
+      ]
     });
     TestBed.overrideComponent(AppHeaderComponent, {
       set: {
         providers: [
           { provide: LoginService, useClass: MockLoginService },
-          { provide: Store, useClass: MockStore },
           { provide: APP_CONFIG, useValue: { facility: "ESS" } }
         ]
       }
@@ -36,7 +49,26 @@ describe("AppHeaderComponent", () => {
     fixture.detectChanges();
   });
 
+  beforeEach(inject([Store], (mockStore: MockStore) => {
+    store = mockStore;
+  }));
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  describe("#logout()", () => {
+    it("should dispatch a LogoutAction", () => {
+      dispatchSpy = spyOn(store, "dispatch");
+
+      component.logout();
+
+      expect(dispatchSpy).toHaveBeenCalledTimes(1);
+      expect(dispatchSpy).toHaveBeenCalledWith(new LogoutAction());
+    });
   });
 });

--- a/src/app/_layout/login-header/login-header.component.html
+++ b/src/app/_layout/login-header/login-header.component.html
@@ -8,7 +8,7 @@
       <h6>
         <a class="toplink" [routerLink]="['/login/help']">
           <i class="material-icons"> help </i>
-          Help</a
+          <span class="large-screen-text">Help</span></a
         >
       </h6>
     </div>
@@ -16,7 +16,7 @@
       <h6>
         <a class="toplink" [routerLink]="['/login/about']">
           <i class="material-icons"> info </i>
-          About</a
+          <span class="large-screen-text">About</span></a
         >
       </h6>
     </div>

--- a/src/app/_layout/login-header/login-header.component.scss
+++ b/src/app/_layout/login-header/login-header.component.scss
@@ -2,6 +2,9 @@
 
 mat-toolbar {
   position: sticky;
+  position: -webkit-sticky;
+  top: 0;
+  z-index: 1000;
 
   height: 5vh;
 
@@ -31,5 +34,11 @@ mat-toolbar {
 
   .material-icons {
     vertical-align: middle;
+  }
+}
+
+@media only screen and (max-width: 1279px) {
+  .large-screen-text {
+    display: none;
   }
 }


### PR DESCRIPTION
## Description

Removes all text except title from header when viewing on small screen

## Motivation

SciCat should be responisve

## Changes:

* Added class to tags containing text and set class to not be displayed on small screens

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?
