### PR TITLE
Added import and switch rules to tslint + ran lint

### DIFF
--- a/e2e/dataset-filter/dataset-filter.e2e-spec.ts
+++ b/e2e/dataset-filter/dataset-filter.e2e-spec.ts
@@ -7,6 +7,7 @@ describe("catanie Dataset Filters", function() {
   let lp: LoginPage;
   let page: DashboardPage;
   const urlParams =
+  // tslint:disable-next-line:max-line-length
     "/datasets?args=(creationLocation:!(),creationTime:(end:!n,start:!n),keywords:!(),limit:30,mode:view,ownerGroup:!(p11114),skip:0,sortField:!n,text:house,type:!())";
 
   beforeAll(() => {

--- a/src/app/_layout/login-layout/login-layout.component.ts
+++ b/src/app/_layout/login-layout/login-layout.component.ts
@@ -1,9 +1,9 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit } from "@angular/core";
 
 @Component({
-  selector: 'app-login-layout',
-  templateUrl: './login-layout.component.html',
-  styleUrls: ['./login-layout.component.scss']
+  selector: "app-login-layout",
+  templateUrl: "./login-layout.component.html",
+  styleUrls: ["./login-layout.component.scss"]
 })
 export class LoginLayoutComponent implements OnInit {
 

--- a/src/app/app-routing/redirect-guard.ts
+++ b/src/app/app-routing/redirect-guard.ts
@@ -1,18 +1,24 @@
-import {Injectable} from "@angular/core";
-import {CanActivate, ActivatedRouteSnapshot, Router, RouterStateSnapshot} from "@angular/router";
-import { Inject } from "@angular/core";
+import { Injectable, Inject } from "@angular/core";
+import {
+  CanActivate,
+  ActivatedRouteSnapshot,
+  Router,
+  RouterStateSnapshot
+} from "@angular/router";
 import { APP_CONFIG, AppConfig } from "app-config.module";
 
 @Injectable()
 export class RedirectGuard implements CanActivate {
+  constructor(
+    private router: Router,
+    @Inject(APP_CONFIG) public appConfig: AppConfig
+  ) {}
 
-  constructor(private router: Router, @Inject(APP_CONFIG) public appConfig: AppConfig) {}
-
-  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
-
-
-      window.location.href = this.appConfig[route.data["urlConfigItem"]];
-      return true;
-
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): boolean {
+    window.location.href = this.appConfig[route.data["urlConfigItem"]];
+    return true;
   }
 }

--- a/src/app/datasets/batch-view/batch-view.component.ts
+++ b/src/app/datasets/batch-view/batch-view.component.ts
@@ -1,11 +1,6 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, OnInit, ViewChild, TemplateRef } from "@angular/core";
 import { select, Store } from "@ngrx/store";
-import {
-  first,
-  map,
-  switchMap,
-  mergeMap
-} from "rxjs/operators";
+import { first, map, switchMap, mergeMap } from "rxjs/operators";
 
 import { getDatasetsInBatch } from "state-management/selectors/datasets.selectors";
 import {
@@ -23,7 +18,6 @@ import { ShareGroupApi } from "shared/sdk/services/custom/ShareGroup";
 import { DatasetApi } from "shared/sdk/services/custom/Dataset";
 import { ShareGroup } from "shared/sdk/models/ShareGroup";
 
-import { ViewChild, TemplateRef } from "@angular/core";
 import { MatDialog } from "@angular/material";
 import { COMMA, ENTER } from "@angular/cdk/keycodes";
 import { MatChipInputEvent } from "@angular/material/chips";
@@ -69,8 +63,7 @@ export class BatchViewComponent implements OnInit {
     private shareGroupApi: ShareGroupApi,
     private datasetApi: DatasetApi,
     private dialog: MatDialog
-  ) // private actionsSubj: ActionsSubject
-  {}
+  ) {}
 
   add(event: MatChipInputEvent): void {
     const input = event.input;

--- a/src/app/datasets/datafiles/datafiles.component.spec.ts
+++ b/src/app/datasets/datafiles/datafiles.component.spec.ts
@@ -7,6 +7,7 @@ import { AppConfigModule } from "app-config.module";
 import { OrigDatablock } from "shared/sdk";
 import { PipesModule } from "shared/pipes/pipes.module";
 
+/* tslint:disable:max-line-length */
 describe("DatafilesComponent", () => {
   let component: DatafilesComponent;
   let fixture: ComponentFixture<DatafilesComponent>;

--- a/src/app/datasets/datafiles/datafiles.component.ts
+++ b/src/app/datasets/datafiles/datafiles.component.ts
@@ -1,14 +1,15 @@
 import { APP_CONFIG, AppConfig } from "app-config.module";
 import { MatTableDataSource, MatPaginator } from "@angular/material";
 import { OrigDatablock, Dataset } from "shared/sdk/models";
-import { ChangeDetectorRef, AfterViewChecked } from "@angular/core";
 import {
   Component,
   Input,
   OnInit,
   ViewChild,
   AfterViewInit,
-  Inject
+  Inject,
+  ChangeDetectorRef,
+  AfterViewChecked
 } from "@angular/core";
 
 @Component({
@@ -30,8 +31,8 @@ export class DatafilesComponent
   count = 0;
   files: Array<any> = [];
   tooLargeFile: boolean;
-  totalFileSize: number = 0;
-  selectedFileSize: number = 0;
+  totalFileSize = 0;
+  selectedFileSize = 0;
 
   areAllSelected = false;
   isNoneSelected = true;

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.spec.ts
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.spec.ts
@@ -28,7 +28,7 @@ describe("DetailsDashboardComponent", () => {
   let component: DatasetDetailsDashboardComponent;
   let fixture: ComponentFixture<DatasetDetailsDashboardComponent>;
 
-  let router = {
+  const router = {
     navigateByUrl: jasmine.createSpy("navigateByUrl")
   };
   let store: MockStore;

--- a/src/app/datasets/dataset-form/dataset-form.component.spec.ts
+++ b/src/app/datasets/dataset-form/dataset-form.component.spec.ts
@@ -158,7 +158,7 @@ describe("DatasetFormComponent", () => {
       expect(component.items.at(0).get("fieldName").value).toEqual("testName");
       expect(component.items.at(0).get("fieldType").value).toEqual("string");
       expect(component.items.at(0).get("fieldValue").value).toEqual(
-        '{"v":100,"u":"Hz"}'
+        "{\"v\":100,\"u\":\"Hz\"}"
       );
       expect(component.items.at(0).get("fieldUnit").status).toEqual("DISABLED");
     });

--- a/src/app/datasets/dataset-form/dataset-form.component.ts
+++ b/src/app/datasets/dataset-form/dataset-form.component.ts
@@ -89,7 +89,7 @@ export class DatasetFormComponent implements OnInit, OnDestroy {
   }
 
   createMetadataObjects(): object {
-    let metadata = {};
+    const metadata = {};
     this.items.controls.forEach(control => {
       metadata[control.value.fieldName] = {
         type: control.value.fieldType

--- a/src/app/datasets/dataset-table/dataset-table.component.spec.ts
+++ b/src/app/datasets/dataset-table/dataset-table.component.spec.ts
@@ -54,7 +54,7 @@ describe("DatasetTableComponent", () => {
   let component: DatasetTableComponent;
   let fixture: ComponentFixture<DatasetTableComponent>;
 
-  let router = {
+  const router = {
     navigateByUrl: jasmine.createSpy("navigateByUrl")
   };
   let store: MockStore;
@@ -233,7 +233,7 @@ describe("DatasetTableComponent", () => {
 
   describe("#userErrorCondition()", () => {
     it("should return true if dataset has missingFilesError", () => {
-      let dataset = new Dataset();
+      const dataset = new Dataset();
       dataset.datasetlifecycle = {
         archiveStatusMessage: "missingFilesError"
       };
@@ -244,7 +244,7 @@ describe("DatasetTableComponent", () => {
     });
 
     it("should return false if dataset has no missingFilesError", () => {
-      let dataset = new Dataset();
+      const dataset = new Dataset();
       dataset.datasetlifecycle = {
         archiveStatusMessage: ""
       };
@@ -257,7 +257,7 @@ describe("DatasetTableComponent", () => {
 
   describe("#archivableCondition()", () => {
     it("should return false if dataset is not archivable and retrievable and does not have a missingFilesError", () => {
-      let dataset = new Dataset();
+      const dataset = new Dataset();
       dataset.datasetlifecycle = {
         archivable: false,
         retrievable: true,
@@ -270,7 +270,7 @@ describe("DatasetTableComponent", () => {
     });
 
     it("should return false if dataset is not archivable and retrievable and does have a missingFilesError", () => {
-      let dataset = new Dataset();
+      const dataset = new Dataset();
       dataset.datasetlifecycle = {
         archivable: false,
         retrievable: true,
@@ -283,7 +283,7 @@ describe("DatasetTableComponent", () => {
     });
 
     it("should return false if dataset is not archivable and not retrievable and does not have a missingFilesError", () => {
-      let dataset = new Dataset();
+      const dataset = new Dataset();
       dataset.datasetlifecycle = {
         archivable: false,
         retrievable: false,
@@ -296,7 +296,7 @@ describe("DatasetTableComponent", () => {
     });
 
     it("should return false if dataset is not archivable and not retrievable and does have a missingFilesError", () => {
-      let dataset = new Dataset();
+      const dataset = new Dataset();
       dataset.datasetlifecycle = {
         archivable: false,
         retrievable: false,
@@ -309,7 +309,7 @@ describe("DatasetTableComponent", () => {
     });
 
     it("should return false if dataset is not archivable and retrievable and does not have a missingFilesError", () => {
-      let dataset = new Dataset();
+      const dataset = new Dataset();
       dataset.datasetlifecycle = {
         archivable: false,
         retrievable: true,
@@ -322,7 +322,7 @@ describe("DatasetTableComponent", () => {
     });
 
     it("should return false if dataset is archivable and retrievable and does not have a missingFilesError", () => {
-      let dataset = new Dataset();
+      const dataset = new Dataset();
       dataset.datasetlifecycle = {
         archivable: true,
         retrievable: true,
@@ -335,7 +335,7 @@ describe("DatasetTableComponent", () => {
     });
 
     it("should return false if dataset is archivable and retrievable and does have a missingFilesError", () => {
-      let dataset = new Dataset();
+      const dataset = new Dataset();
       dataset.datasetlifecycle = {
         archivable: true,
         retrievable: true,
@@ -348,7 +348,7 @@ describe("DatasetTableComponent", () => {
     });
 
     it("should return true if dataset is archivable and not retrievable and does not have a missingFilesError", () => {
-      let dataset = new Dataset();
+      const dataset = new Dataset();
       dataset.datasetlifecycle = {
         archivable: true,
         retrievable: false,
@@ -363,7 +363,7 @@ describe("DatasetTableComponent", () => {
 
   describe("#retrievableCondition()", () => {
     it("should return false if dataset is archivable and not retrievable", () => {
-      let dataset = new Dataset();
+      const dataset = new Dataset();
       dataset.datasetlifecycle = {
         archivable: true,
         retrievable: false
@@ -375,7 +375,7 @@ describe("DatasetTableComponent", () => {
     });
 
     it("should return false if dataset is not archivable and not retrievable", () => {
-      let dataset = new Dataset();
+      const dataset = new Dataset();
       dataset.datasetlifecycle = {
         archivable: false,
         retrievable: false
@@ -387,7 +387,7 @@ describe("DatasetTableComponent", () => {
     });
 
     it("should return false if dataset is archivable and retrievable", () => {
-      let dataset = new Dataset();
+      const dataset = new Dataset();
       dataset.datasetlifecycle = {
         archivable: true,
         retrievable: true
@@ -399,7 +399,7 @@ describe("DatasetTableComponent", () => {
     });
 
     it("should return true if dataset is retrievable and not archivable", () => {
-      let dataset = new Dataset();
+      const dataset = new Dataset();
       dataset.datasetlifecycle = {
         archivable: false,
         retrievable: true
@@ -445,7 +445,7 @@ describe("DatasetTableComponent", () => {
     it("should dispatch a SelectDatasetAction if checked is true", () => {
       dispatchSpy = spyOn(store, "dispatch");
 
-      let event = new MatCheckboxChange();
+      const event = new MatCheckboxChange();
       event.checked = true;
       const dataset = new Dataset();
       component.onSelect(event, dataset);
@@ -459,7 +459,7 @@ describe("DatasetTableComponent", () => {
     it("should dispatch a DeselectDatasetAction if checked is false", () => {
       dispatchSpy = spyOn(store, "dispatch");
 
-      let event = new MatCheckboxChange();
+      const event = new MatCheckboxChange();
       event.checked = false;
       const dataset = new Dataset();
       component.onSelect(event, dataset);
@@ -475,7 +475,7 @@ describe("DatasetTableComponent", () => {
     it("should dispatch a SelectAllDatasetsAction if checked is true", () => {
       dispatchSpy = spyOn(store, "dispatch");
 
-      let event = new MatCheckboxChange();
+      const event = new MatCheckboxChange();
       event.checked = true;
       component.onSelectAll(event);
 
@@ -486,7 +486,7 @@ describe("DatasetTableComponent", () => {
     it("should dispatch a ClearSelectionAction if checked is false", () => {
       dispatchSpy = spyOn(store, "dispatch");
 
-      let event = new MatCheckboxChange();
+      const event = new MatCheckboxChange();
       event.checked = false;
       component.onSelectAll(event);
 

--- a/src/app/datasets/dataset-table/dataset-table.component.ts
+++ b/src/app/datasets/dataset-table/dataset-table.component.ts
@@ -5,7 +5,11 @@ import { Dataset, MessageType, ArchViewMode } from "state-management/models";
 import { DialogComponent } from "shared/modules/dialog/dialog.component";
 import { MatCheckboxChange, MatDialog } from "@angular/material";
 import { Router } from "@angular/router";
-import { ShowMessageAction } from "state-management/actions/user.actions";
+import {
+  ShowMessageAction,
+  SelectColumnAction,
+  DeselectColumnAction
+} from "state-management/actions/user.actions";
 import { Subscription } from "rxjs";
 import {
   getDisplayedColumns,
@@ -35,6 +39,7 @@ import {
   getViewMode,
   getViewPublicMode
 } from "state-management/selectors/datasets.selectors";
+import { FormControl } from "@angular/forms";
 
 export interface PageChangeEvent {
   pageIndex: number;
@@ -47,16 +52,10 @@ export interface SortChangeEvent {
   direction: "asc" | "desc" | "";
 }
 
-export interface datasetDerivationsMap {
+export interface DatasetDerivationsMap {
   datasetPid: string;
   derivedDatasetsNum: number;
 }
-
-import {
-  SelectColumnAction,
-  DeselectColumnAction
-} from "state-management/actions/user.actions";
-import { FormControl } from "@angular/forms";
 
 @Component({
   selector: "dataset-table",
@@ -72,7 +71,7 @@ export class DatasetTableComponent implements OnInit, OnDestroy {
 
   datasetsSubscription: Subscription;
   datasetPids: string[] = [];
-  datasetDerivationsMaps: datasetDerivationsMap[] = [];
+  datasetDerivationsMaps: DatasetDerivationsMap[] = [];
   derivationMapPids: string[] = [];
 
   public currentMode: ArchViewMode;
@@ -118,7 +117,7 @@ export class DatasetTableComponent implements OnInit, OnDestroy {
   });
 
   searchPublicDataEnabled = this.appConfig.searchPublicDataEnabled;
-  viewPublic: boolean = false;
+  viewPublic = false;
   viewPublicSubscription: Subscription;
 
   constructor(
@@ -175,7 +174,7 @@ export class DatasetTableComponent implements OnInit, OnDestroy {
         );
         datasets.forEach(dataset => {
           if (!this.derivationMapPids.includes(dataset.pid)) {
-            let map: datasetDerivationsMap = {
+            const map: DatasetDerivationsMap = {
               datasetPid: dataset.pid,
               derivedDatasetsNum: this.countDerivedDatasets(dataset)
             };
@@ -389,7 +388,7 @@ export class DatasetTableComponent implements OnInit, OnDestroy {
   }
 
   countDerivedDatasets(dataset: Dataset): number {
-    let derivedDatasetsNum: number = 0;
+    let derivedDatasetsNum = 0;
     if (dataset.history) {
       dataset.history.forEach(item => {
         if (

--- a/src/app/datasets/datasets-filter/datasets-filter.component.ts
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.ts
@@ -46,10 +46,10 @@ import {
 import { ScientificConditionDialogComponent } from "datasets/scientific-condition-dialog/scientific-condition-dialog.component";
 import { combineLatest, BehaviorSubject, Observable } from "rxjs";
 
-export type DateRange = {
+export interface DateRange {
   begin: Date;
   end: Date;
-};
+}
 
 @Component({
   selector: "datasets-filter",
@@ -76,27 +76,7 @@ export class DatasetsFilterComponent {
   typeInput$ = new BehaviorSubject<string>("");
   keywordsInput$ = new BehaviorSubject<string>("");
 
-  clearSearchBar: boolean = false;
-
-  createSuggestionObserver(
-    facetCounts$: Observable<FacetCount[]>,
-    input$: BehaviorSubject<string>,
-    currentFilters$: Observable<string[]>
-  ): Observable<FacetCount[]> {
-    return combineLatest(facetCounts$, input$, currentFilters$).pipe(
-      map(([counts, filterString, currentFilters]) => {
-        if (!counts) {
-          return [];
-        }
-        return counts.filter(
-          count =>
-            typeof count._id === "string" &&
-            count._id.toLowerCase().includes(filterString.toLowerCase()) &&
-            currentFilters.indexOf(count._id) < 0
-        );
-      })
-    );
-  }
+  clearSearchBar = false;
   groupSuggestions$ = this.createSuggestionObserver(
     this.groupFacetCounts$,
     this.groupInput$,
@@ -142,6 +122,26 @@ export class DatasetsFilterComponent {
     .subscribe(terms => {
       this.store.dispatch(new AddKeywordFilterAction(terms));
     });
+
+  createSuggestionObserver(
+    facetCounts$: Observable<FacetCount[]>,
+    input$: BehaviorSubject<string>,
+    currentFilters$: Observable<string[]>
+  ): Observable<FacetCount[]> {
+    return combineLatest(facetCounts$, input$, currentFilters$).pipe(
+      map(([counts, filterString, currentFilters]) => {
+        if (!counts) {
+          return [];
+        }
+        return counts.filter(
+          count =>
+            typeof count._id === "string" &&
+            count._id.toLowerCase().includes(filterString.toLowerCase()) &&
+            currentFilters.indexOf(count._id) < 0
+        );
+      })
+    );
+  }
 
   constructor(
     public dialog: MatDialog,

--- a/src/app/datasets/metadata-table/metadata-table.component.spec.ts
+++ b/src/app/datasets/metadata-table/metadata-table.component.spec.ts
@@ -63,7 +63,7 @@ describe("MetadataTableComponent", () => {
 
       expect(metadataArray[0].name).toEqual("untypedTestName");
       expect(metadataArray[0].type).toEqual("");
-      expect(metadataArray[0].value).toEqual('{"v":"test","u":""}');
+      expect(metadataArray[0].value).toEqual("{\"v\":\"test\",\"u\":\"\"}");
       expect(metadataArray[0].unit).toEqual("");
     });
   });

--- a/src/app/datasets/metadata-table/metadata-table.component.ts
+++ b/src/app/datasets/metadata-table/metadata-table.component.ts
@@ -15,25 +15,27 @@ export class MetadataTableComponent implements OnInit, OnDestroy {
   public displayMetadataColumns = ["name", "value", "unit"];
 
   createMetadataArray(scientificMetadata) {
-    let objects = [];
-    for (const key in scientificMetadata) {
-      let metadataObject = {};
-      if ("type" in scientificMetadata[key]) {
-        metadataObject = {
-          name: key,
-          type: scientificMetadata[key].type,
-          value: scientificMetadata[key].value,
-          unit: scientificMetadata[key].unit
-        };
-      } else {
-        metadataObject = {
-          name: key,
-          type: "",
-          value: JSON.stringify(scientificMetadata[key]),
-          unit: ""
-        };
-      }
-      objects.push(metadataObject);
+    const objects = [];
+    if (scientificMetadata) {
+      Object.keys(scientificMetadata).forEach(key => {
+        let metadataObject = {};
+        if ("type" in scientificMetadata[key]) {
+          metadataObject = {
+            name: key,
+            type: scientificMetadata[key].type,
+            value: scientificMetadata[key].value,
+            unit: scientificMetadata[key].unit
+          };
+        } else {
+          metadataObject = {
+            name: key,
+            type: "",
+            value: JSON.stringify(scientificMetadata[key]),
+            unit: ""
+          };
+        }
+        objects.push(metadataObject);
+      });
     }
     return objects;
   }

--- a/src/app/datasets/publish/publish.component.ts
+++ b/src/app/datasets/publish/publish.component.ts
@@ -1,7 +1,7 @@
 import { Component, Inject, OnInit } from "@angular/core";
 import { COMMA, ENTER } from "@angular/cdk/keycodes";
 
-import { select, Store } from "@ngrx/store";
+import { select, Store, ActionsSubject } from "@ngrx/store";
 import { map, first, tap } from "rxjs/operators";
 
 import { getDatasetsInBatch } from "state-management/selectors/datasets.selectors";
@@ -19,7 +19,6 @@ import { formatDate } from "@angular/common";
 import { MessageType } from "state-management/models";
 import { ShowMessageAction } from "state-management/actions/user.actions";
 import { Router } from "@angular/router";
-import { ActionsSubject } from "@ngrx/store";
 
 @Component({
   selector: "publish",
@@ -59,14 +58,14 @@ export class PublishComponent implements OnInit {
     @Inject(APP_CONFIG) private appConfig,
     private publishedDataApi: PublishedDataApi,
     private actionsSubj: ActionsSubject,
-    private router: Router,
+    private router: Router
   ) {
     this.subsc = this.actionsSubj.subscribe(data => {
       if (data.type === PublishedDataActionTypes.AddPublishedData) {
         this.store.dispatch(
           new ShowMessageAction({
             type: MessageType.Success,
-            content: "Publication Successful" ,
+            content: "Publication Successful",
             duration: 5000
           })
         );

--- a/src/app/jobs/jobs-dashboard/jobs-dashboard.component.spec.ts
+++ b/src/app/jobs/jobs-dashboard/jobs-dashboard.component.spec.ts
@@ -27,7 +27,7 @@ describe("JobsDashboardComponent", () => {
   let component: JobsDashboardComponent;
   let fixture: ComponentFixture<JobsDashboardComponent>;
 
-  let router = {
+  const router = {
     navigateByUrl: jasmine.createSpy("navigateByUrl")
   };
   let store: MockStore;
@@ -148,7 +148,7 @@ describe("JobsDashboardComponent", () => {
     it("should dispatch a CurrentJobAction and navigate to a job", () => {
       dispatchSpy = spyOn(store, "dispatch");
 
-      let job = new Job();
+      const job = new Job();
       job.id = "test";
       component.onRowClick(job);
 

--- a/src/app/jobs/jobs-dashboard/jobs-dashboard.component.ts
+++ b/src/app/jobs/jobs-dashboard/jobs-dashboard.component.ts
@@ -29,11 +29,6 @@ import {
   styleUrls: ["./jobs-dashboard.component.scss"]
 })
 export class JobsDashboardComponent implements OnInit, OnDestroy {
-  constructor(
-    private datePipe: DatePipe,
-    private router: Router,
-    private store: Store<Job>
-  ) {}
 
   jobs: any[] = [];
   jobsSubscription: Subscription;
@@ -62,6 +57,11 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
     },
     { name: "statusMessage", icon: "comment", sort: false, inList: true }
   ];
+  constructor(
+    private datePipe: DatePipe,
+    private router: Router,
+    private store: Store<Job>
+  ) {}
 
   formatTableData(jobs: Job[]): any[] {
     if (jobs) {

--- a/src/app/policies/policies-dashboard/policies-dashboard.component.spec.ts
+++ b/src/app/policies/policies-dashboard/policies-dashboard.component.spec.ts
@@ -105,7 +105,7 @@ describe("PoliciesDashboardComponent", () => {
     it("should dispatch a SelectPolicyAction if checked is true", () => {
       dispatchSpy = spyOn(store, "dispatch");
 
-      let checkboxEvent: CheckboxEvent = {
+      const checkboxEvent: CheckboxEvent = {
         event: new MatCheckboxChange(),
         row: new Policy()
       };
@@ -121,7 +121,7 @@ describe("PoliciesDashboardComponent", () => {
     it("should dispatch a DeselectPolicyAction if checked is false", () => {
       dispatchSpy = spyOn(store, "dispatch");
 
-      let checkboxEvent: CheckboxEvent = {
+      const checkboxEvent: CheckboxEvent = {
         event: new MatCheckboxChange(),
         row: new Policy()
       };

--- a/src/app/policies/policies-dashboard/policies-dashboard.component.ts
+++ b/src/app/policies/policies-dashboard/policies-dashboard.component.ts
@@ -40,11 +40,6 @@ import { map } from "rxjs/operators";
   styleUrls: ["./policies-dashboard.component.scss"]
 })
 export class PoliciesDashboardComponent implements OnInit, OnDestroy {
-  constructor(
-    private datasetApi: DatasetApi,
-    public dialog: MatDialog,
-    private store: Store<Policy>
-  ) {}
 
   policies$: Observable<Policy[]> = this.store.pipe(select(getPolicies));
   editablePolicies$: Observable<Policy[]> = this.store.pipe(
@@ -57,7 +52,7 @@ export class PoliciesDashboardComponent implements OnInit, OnDestroy {
     select(getEditableCount)
   );
 
-  multiSelect: boolean = false;
+  multiSelect = false;
   selectedIds: string[] = [];
   selectedGroups: string[] = [];
   selectedPolicies: Policy[] = [];
@@ -65,8 +60,8 @@ export class PoliciesDashboardComponent implements OnInit, OnDestroy {
 
   dialogConfig: MatDialogConfig;
 
-  editEnabled: boolean = true;
-  paginate: boolean = true;
+  editEnabled = true;
+  paginate = true;
   tableColumns: TableColumn[] = [
     { name: "manager", icon: "account_box", sort: true, inList: true },
     { name: "ownerGroup", icon: "people", sort: true, inList: true },
@@ -98,6 +93,11 @@ export class PoliciesDashboardComponent implements OnInit, OnDestroy {
       inList: true
     }
   ];
+  constructor(
+    private datasetApi: DatasetApi,
+    public dialog: MatDialog,
+    private store: Store<Policy>
+  ) {}
 
   onPageChange(event: PageChangeEvent) {
     this.store.dispatch(new ChangePageAction(event.pageIndex, event.pageSize));

--- a/src/app/proposals/proposal-dashboard/proposal-dashboard.component.spec.ts
+++ b/src/app/proposals/proposal-dashboard/proposal-dashboard.component.spec.ts
@@ -44,7 +44,7 @@ describe("ProposalDashboardComponent", () => {
   let component: ProposalDashboardComponent;
   let fixture: ComponentFixture<ProposalDashboardComponent>;
 
-  let router = {
+  const router = {
     navigateByUrl: jasmine.createSpy("navigateByUrl")
   };
   let store: MockStore;

--- a/src/app/proposals/proposal-dashboard/proposal-dashboard.component.ts
+++ b/src/app/proposals/proposal-dashboard/proposal-dashboard.component.ts
@@ -32,12 +32,6 @@ import { distinctUntilChanged, map } from "rxjs/operators";
   styleUrls: ["./proposal-dashboard.component.scss"]
 })
 export class ProposalDashboardComponent implements OnInit, OnDestroy {
-  constructor(
-    @Inject(APP_CONFIG) public appConfig: AppConfig,
-    private datePipe: DatePipe,
-    private router: Router,
-    private store: Store<Proposal>
-  ) {}
 
   private proposalSubscription: Subscription;
   private hasFetchedSubscription: Subscription;
@@ -61,11 +55,17 @@ export class ProposalDashboardComponent implements OnInit, OnDestroy {
     { name: "end", icon: "timer_off", sort: false, inList: true }
   ];
   tablePaginate = true;
+  constructor(
+    @Inject(APP_CONFIG) public appConfig: AppConfig,
+    private datePipe: DatePipe,
+    private router: Router,
+    private store: Store<Proposal>
+  ) {}
 
   formatTableData(proposals: Proposal[]): any[] {
     if (proposals) {
       return proposals.map(proposal => {
-        let data: any = {
+        const data: any = {
           proposalId: proposal.proposalId,
           title: proposal.title,
           author: proposal.firstname + " " + proposal.lastname

--- a/src/app/proposals/proposal-detail/proposal-detail.component.ts
+++ b/src/app/proposals/proposal-detail/proposal-detail.component.ts
@@ -9,7 +9,7 @@ import { Proposal } from "state-management/models";
 export class ProposalDetailComponent implements OnInit {
   @Input() proposal: Proposal;
 
-  show: boolean = false;
+  show = false;
 
   constructor() {}
 

--- a/src/app/proposals/view-proposal-page/view-proposal-page.component.spec.ts
+++ b/src/app/proposals/view-proposal-page/view-proposal-page.component.spec.ts
@@ -20,7 +20,7 @@ describe("ViewProposalPageComponent", () => {
   let component: ViewProposalPageComponent;
   let fixture: ComponentFixture<ViewProposalPageComponent>;
 
-  let router = {
+  const router = {
     navigateByUrl: jasmine.createSpy("navigateByUrl")
   };
   let store: MockStore;

--- a/src/app/proposals/view-proposal-page/view-proposal-page.component.ts
+++ b/src/app/proposals/view-proposal-page/view-proposal-page.component.ts
@@ -38,7 +38,7 @@ export class ViewProposalPageComponent implements OnInit, OnDestroy {
   datasetsSubscription: Subscription;
   routeSubscription: Subscription;
 
-  tablePaginate: boolean = true;
+  tablePaginate = true;
   tableData: any[];
   tableColumns: TableColumn[] = [
     { name: "name", icon: "portrait", sort: false, inList: true },

--- a/src/app/publisheddata/publisheddata-dashboard/publisheddata-dashboard.component.spec.ts
+++ b/src/app/publisheddata/publisheddata-dashboard/publisheddata-dashboard.component.spec.ts
@@ -19,7 +19,7 @@ describe("PublisheddataDashboardComponent", () => {
   let component: PublisheddataDashboardComponent;
   let fixture: ComponentFixture<PublisheddataDashboardComponent>;
 
-  let router = {
+  const router = {
     navigateByUrl: jasmine.createSpy("navigateByUrl")
   };
   let store: MockStore;

--- a/src/app/publisheddata/publisheddata-dashboard/publisheddata-dashboard.component.ts
+++ b/src/app/publisheddata/publisheddata-dashboard/publisheddata-dashboard.component.ts
@@ -23,7 +23,6 @@ import {
   styleUrls: ["./publisheddata-dashboard.component.scss"]
 })
 export class PublisheddataDashboardComponent implements OnInit {
-  constructor(private router: Router, private store: Store<PublishedData>) {}
 
   public publishedData$ = this.store.pipe(select(selectAllPublished));
   public count$ = this.store.pipe(select(getCount));
@@ -37,6 +36,7 @@ export class PublisheddataDashboardComponent implements OnInit {
     { name: "publicationYear", icon: "date_range", sort: false, inList: true }
   ];
   paginate = true;
+  constructor(private router: Router, private store: Store<PublishedData>) {}
 
   onPageChange(event: PageChangeEvent) {
     this.store.dispatch(

--- a/src/app/samples/sample-dashboard/sample-dashboard.component.spec.ts
+++ b/src/app/samples/sample-dashboard/sample-dashboard.component.spec.ts
@@ -30,7 +30,7 @@ describe("SampleDashboardComponent", () => {
   let component: SampleDashboardComponent;
   let fixture: ComponentFixture<SampleDashboardComponent>;
 
-  let router = {
+  const router = {
     navigateByUrl: jasmine.createSpy("navigateByUrl")
   };
   let store: MockStore;

--- a/src/app/samples/sample-dashboard/sample-dashboard.component.ts
+++ b/src/app/samples/sample-dashboard/sample-dashboard.component.ts
@@ -33,13 +33,6 @@ import { SampleDialogComponent } from "samples/sample-dialog/sample-dialog.compo
   styleUrls: ["./sample-dashboard.component.scss"]
 })
 export class SampleDashboardComponent implements OnInit, OnDestroy {
-  constructor(
-    @Inject(APP_CONFIG) public appConfig: AppConfig,
-    private datePipe: DatePipe,
-    public dialog: MatDialog,
-    private router: Router,
-    private store: Store<Sample>
-  ) {}
 
   sampleSubscription: Subscription;
 
@@ -60,6 +53,13 @@ export class SampleDashboardComponent implements OnInit, OnDestroy {
   dialogConfig: MatDialogConfig;
   name: string;
   description: string;
+  constructor(
+    @Inject(APP_CONFIG) public appConfig: AppConfig,
+    private datePipe: DatePipe,
+    public dialog: MatDialog,
+    private router: Router,
+    private store: Store<Sample>
+  ) {}
 
   formatTableData(samples: Sample[]): any {
     if (samples) {

--- a/src/app/shared/MockStubs.ts
+++ b/src/app/shared/MockStubs.ts
@@ -87,17 +87,17 @@ export class MockActivatedRoute {
 }
 
 export class MockRouter {
+
+  events = new Observable(observer => {
+    observer.next();
+    observer.complete();
+  });
   navigate = function(url, params) {};
 
   // jasmine.createSpy('navigate');
   navigateByUrl(url: string) {
     return url;
   }
-
-  events = new Observable(observer => {
-    observer.next();
-    observer.complete();
-  });
 
   createUrlTree = (commands, navExtras = {}) => {};
   serializeUrl = (url: UrlTree) => "";

--- a/src/app/shared/modules/dialog/dialog.component.spec.ts
+++ b/src/app/shared/modules/dialog/dialog.component.spec.ts
@@ -1,6 +1,10 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
-import { MatDialogRef, MAT_DIALOG_DATA } from "@angular/material";
-import { MatDialogModule, MatFormFieldModule } from "@angular/material";
+import {
+  MatDialogModule,
+  MatFormFieldModule,
+  MatDialogRef,
+  MAT_DIALOG_DATA
+} from "@angular/material";
 import { CommonModule } from "@angular/common";
 import { FormsModule } from "@angular/forms";
 import { DialogComponent } from "./dialog.component";

--- a/src/app/shared/modules/search-bar/search-bar.component.ts
+++ b/src/app/shared/modules/search-bar/search-bar.component.ts
@@ -52,7 +52,7 @@ export class SearchBarComponent implements OnChanges {
   constructor() {}
 
   ngOnChanges(changes: { [propKey: string]: SimpleChange }) {
-    for (let propName in changes) {
+    for (const propName in changes) {
       if (propName === "clear" && changes[propName].currentValue === true) {
         this.query = "";
       }

--- a/src/app/shared/modules/table/table.component.ts
+++ b/src/app/shared/modules/table/table.component.ts
@@ -47,11 +47,11 @@ export class TableComponent implements OnInit {
   @Input() dataPerPage?: number;
   pageSizeOptions = [10, 25, 50, 100, 500, 1000];
 
-  @Output() pageChange? = new EventEmitter<PageChangeEvent>();
-  @Output() sortChange? = new EventEmitter<SortChangeEvent>();
-  @Output() rowClick? = new EventEmitter<any>();
-  @Output() selectAll? = new EventEmitter<MatCheckboxChange>();
-  @Output() selectOne? = new EventEmitter<CheckboxEvent>();
+  @Output() pageChange ? = new EventEmitter<PageChangeEvent>();
+  @Output() sortChange ? = new EventEmitter<SortChangeEvent>();
+  @Output() rowClick ? = new EventEmitter<any>();
+  @Output() selectAll ? = new EventEmitter<MatCheckboxChange>();
+  @Output() selectOne ? = new EventEmitter<CheckboxEvent>();
 
   constructor() {}
 

--- a/src/app/state-management/actions/jobs.actions.spec.ts
+++ b/src/app/state-management/actions/jobs.actions.spec.ts
@@ -1,15 +1,26 @@
 import { Job } from "shared/sdk/models";
-import { SubmitAction, SUBMIT } from "./jobs.actions";
-import { SubmitCompleteAction, SUBMIT_COMPLETE } from "./jobs.actions";
-import { FailedAction, FAILED } from "./jobs.actions";
-import { RetrieveCompleteAction, RETRIEVE_COMPLETE } from "./jobs.actions";
-import { SearchIDAction, SEARCH_ID } from "./jobs.actions";
-import { SearchIDCompleteAction, SEARCH_ID_COMPLETE } from "./jobs.actions";
-import { SearchIDFailedAction, SEARCH_ID_FAILED } from "./jobs.actions";
-import { CurrentJobAction, SELECT_CURRENT } from "./jobs.actions";
-import { SortUpdateAction, SORT_UPDATE } from "./jobs.actions";
-import { GetCountCompleteAction, GET_COUNT_COMPLETE } from "./jobs.actions";
-
+import {
+  SubmitAction,
+  SUBMIT,
+  SubmitCompleteAction,
+  SUBMIT_COMPLETE,
+  FailedAction,
+  FAILED,
+  RetrieveCompleteAction,
+  RETRIEVE_COMPLETE,
+  SearchIDAction,
+  SEARCH_ID,
+  SearchIDCompleteAction,
+  SEARCH_ID_COMPLETE,
+  SearchIDFailedAction,
+  SEARCH_ID_FAILED,
+  CurrentJobAction,
+  SELECT_CURRENT,
+  SortUpdateAction,
+  SORT_UPDATE,
+  GetCountCompleteAction,
+  GET_COUNT_COMPLETE
+} from "./jobs.actions";
 
 describe("SubmitAction", () => {
   it("should create an action", () => {

--- a/src/app/state-management/actions/user.actions.spec.ts
+++ b/src/app/state-management/actions/user.actions.spec.ts
@@ -1,30 +1,30 @@
 import { Message, User, Settings } from "../models";
-import { LoginAction, LOGIN } from "./user.actions";
-import { ActiveDirLoginAction, AD_LOGIN } from "./user.actions";
-import { LoginCompleteAction, LOGIN_COMPLETE } from "./user.actions";
-import { LoginFailedAction, LOGIN_FAILED } from "./user.actions";
-import { LogoutAction, LOGOUT } from "./user.actions";
-import { LogoutCompleteAction, LOGOUT_COMPLETE } from "./user.actions";
-import { RetrieveUserAction, RETRIEVE_USER } from "./user.actions";
 import {
+  LoginAction,
+  LOGIN,
+  ActiveDirLoginAction,
+  AD_LOGIN,
+  LoginCompleteAction,
+  LOGIN_COMPLETE,
+  LoginFailedAction,
+  LOGIN_FAILED,
+  LogoutAction,
+  LOGOUT,
+  LogoutCompleteAction,
+  LOGOUT_COMPLETE,
+  RetrieveUserAction,
+  RETRIEVE_USER,
   RetrieveUserCompleteAction,
-  RETRIEVE_USER_COMPLETE
+  RETRIEVE_USER_COMPLETE,
+  RetrieveUserFailedAction,
+  RETRIEVE_USER_FAILED,
+  ShowMessageAction,
+  SHOW_MESSAGE,
+  ClearMessageAction,
+  CLEAR_MESSAGE,
+  SaveSettingsAction,
+  SAVE_SETTINGS
 } from "./user.actions";
-import { RetrieveUserFailedAction, RETRIEVE_USER_FAILED } from "./user.actions";
-/*
-import { AccessUserEmailAction, ACCESS_USER_EMAIL } from "./user.actions";
-import {
-  AccessUserEmailCompleteAction,
-  ACCESS_USER_EMAIL_COMPLETE
-} from "./user.actions";
-import {
-  AccessUserEmailFailedAction,
-  ACCESS_USER_EMAIL_FAILED
-} from "./user.actions";
-*/
-import { ShowMessageAction, SHOW_MESSAGE } from "./user.actions";
-import { ClearMessageAction, CLEAR_MESSAGE } from "./user.actions";
-import { SaveSettingsAction, SAVE_SETTINGS } from "./user.actions";
 
 describe("LoginAction", () => {
   it("should create an action", () => {

--- a/src/app/state-management/effects/datasets.effects.ts
+++ b/src/app/state-management/effects/datasets.effects.ts
@@ -51,7 +51,10 @@ export class DatasetEffects {
     map((action: DatasetActions.SaveDatasetAction) => action.dataset),
     switchMap(dataset => {
       return this.datasetApi.updateScientificMetadata(dataset).pipe(
-        map(dataset => new DatasetActions.SaveDatasetCompleteAction(dataset)),
+        map(
+          savedDataset =>
+            new DatasetActions.SaveDatasetCompleteAction(savedDataset)
+        ),
         catchError(err => of(new DatasetActions.SaveDatasetFailedAction(err)))
       );
     })
@@ -104,7 +107,7 @@ export class DatasetEffects {
     ofType(DatasetActions.DATABLOCKS),
     map((action: DatasetActions.DatablocksAction) => action),
     switchMap(action => {
-      let filter = {
+      const datasetFilter = {
         where: {
           pid: action.id
         },
@@ -117,13 +120,13 @@ export class DatasetEffects {
 
       if (action.filter) {
         Object.keys(action.filter).forEach(key => {
-          filter.where[key] = action.filter[key];
+          datasetFilter.where[key] = action.filter[key];
         });
       }
 
       // TODO separate action for dataBlocks? or retrieve at once?
 
-      return this.datasetApi.findOne(filter).pipe(
+      return this.datasetApi.findOne(datasetFilter).pipe(
         map(
           (dataset: Dataset) =>
             new DatasetActions.SearchIDCompleteAction(dataset)

--- a/src/app/state-management/effects/jobs.effects.ts
+++ b/src/app/state-management/effects/jobs.effects.ts
@@ -3,8 +3,7 @@
 import { Injectable } from "@angular/core";
 import { Actions, Effect, ofType } from "@ngrx/effects";
 import { Action } from "@ngrx/store";
-import { Observable } from "rxjs";
-import { of } from "rxjs";
+import { Observable, of } from "rxjs";
 import * as lb from "shared/sdk/services";
 import * as JobActions from "state-management/actions/jobs.actions";
 import * as UserActions from "state-management/actions/user.actions";
@@ -82,8 +81,5 @@ export class JobsEffects {
     })
   );
 
-  constructor(
-    private action$: Actions,
-    private jobSrv: lb.JobApi,
-  ) {}
+  constructor(private action$: Actions, private jobSrv: lb.JobApi) {}
 }

--- a/src/app/state-management/reducers/datasets.reducer.ts
+++ b/src/app/state-management/reducers/datasets.reducer.ts
@@ -144,7 +144,7 @@ export function datasetsReducer(
       const updatedAttachment = (action as UpdateAttachmentCaptionCompleteAction)
         .attachment;
       const attachments = state.currentSet.attachments;
-      let attach2 = attachments.filter(
+      const attach2 = attachments.filter(
         attachment => attachment.id !== updatedAttachment.id
       );
       attach2.push(updatedAttachment);
@@ -403,6 +403,9 @@ export function datasetsReducer(
             ]
           };
           break;
+        default: {
+          break;
+        }
       }
       const skip = 0;
       const filters = { ...state.filters, skip, mode, modeToggle };

--- a/src/app/state-management/reducers/logbooks.reducer.spec.ts
+++ b/src/app/state-management/reducers/logbooks.reducer.spec.ts
@@ -7,7 +7,7 @@ import { APP_DI_CONFIG } from "app-config.module";
 describe("LogbooksReducer", () => {
   describe("default", () => {
     it("should return the initial state", () => {
-      let filter: LogbookFilters = {
+      const filter: LogbookFilters = {
         textSearch: "",
         showBotMessages: true,
         showImages: true,
@@ -86,7 +86,7 @@ describe("LogbooksReducer", () => {
   describe("#formatImageUrls", () => {
     it("should reformat 'mxc://' urls to 'http(s)://' urls", () => {
       const logbook = new Logbook();
-      const message = {
+      const inputMessage = {
         content: {
           info: {
             thumbnail_url: "mxc://"
@@ -95,7 +95,7 @@ describe("LogbooksReducer", () => {
           url: "mxc://"
         }
       };
-      logbook.messages = [message];
+      logbook.messages = [inputMessage];
       formatImageUrls(logbook);
 
       logbook.messages.forEach(message => {
@@ -124,7 +124,7 @@ describe("LogbooksReducer", () => {
 
     it("should do nothing if msgtype is not 'm.image'", () => {
       const logbook = new Logbook();
-      const message = {
+      const inputMessage = {
         content: {
           info: {
             thumbnail_url: "mxc://"
@@ -133,7 +133,7 @@ describe("LogbooksReducer", () => {
           url: "mxc://"
         }
       };
-      logbook.messages = [message];
+      logbook.messages = [inputMessage];
       formatImageUrls(logbook);
 
       logbook.messages.forEach(message => {
@@ -144,14 +144,14 @@ describe("LogbooksReducer", () => {
 
     it("should only format 'url' if there is no 'thumbnail_url' property", () => {
       const logbook = new Logbook();
-      const message = {
+      const inputMessage = {
         content: {
           info: {},
           msgtype: "m.image",
           url: "mxc://"
         }
       };
-      logbook.messages = [message];
+      logbook.messages = [inputMessage];
       formatImageUrls(logbook);
 
       logbook.messages.forEach(message => {
@@ -164,7 +164,7 @@ describe("LogbooksReducer", () => {
 
     it("should only format 'thumbnail_url' if there is no 'url' property", () => {
       const logbook = new Logbook();
-      const message = {
+      const inputMessage = {
         content: {
           info: {
             thumbnail_url: "mxc://"
@@ -172,7 +172,7 @@ describe("LogbooksReducer", () => {
           msgtype: "m.image"
         }
       };
-      logbook.messages = [message];
+      logbook.messages = [inputMessage];
       formatImageUrls(logbook);
 
       logbook.messages.forEach(message => {
@@ -185,13 +185,13 @@ describe("LogbooksReducer", () => {
 
     it("should do nothing if there are no properties 'thumbnail_url' and 'url'", () => {
       const logbook = new Logbook();
-      const message = {
+      const inputMessage = {
         content: {
           info: {},
           msgtype: "m.image"
         }
       };
-      logbook.messages = [message];
+      logbook.messages = [inputMessage];
       formatImageUrls(logbook);
 
       logbook.messages.forEach(message => {

--- a/src/app/state-management/reducers/proposals.reducer.ts
+++ b/src/app/state-management/reducers/proposals.reducer.ts
@@ -69,8 +69,8 @@ export function proposalsReducer(
       const list = (action as FetchProposalsCompleteAction).proposals;
       const proposalsLoading = false;
       const proposals = list.reduce(
-        (proposals, proposal) => ({
-          ...proposals,
+        (existingProposals, proposal) => ({
+          ...existingProposals,
           [proposal.proposalId]: proposal
         }),
         {}
@@ -84,7 +84,10 @@ export function proposalsReducer(
     case FETCH_DATASETS_FOR_PROPOSAL_COMPLETE: {
       const list = (action as FetchDatasetsForProposalCompleteAction).datasets;
       const datasets = list.reduce(
-        (datasets, dataset) => ({ ...datasets, [dataset.pid]: dataset }),
+        (existingDatasets, dataset) => ({
+          ...existingDatasets,
+          [dataset.pid]: dataset
+        }),
         {}
       );
       const datasetCount = Object.keys(datasets).length;
@@ -150,7 +153,7 @@ export function proposalsReducer(
       const updatedAttachment = (action as UpdateAttachmentCaptionCompleteAction)
         .attachment;
       const attachments = state.currentProposal.attachments;
-      let attach2 = attachments.filter(
+      const attach2 = attachments.filter(
         attachment => attachment.id !== updatedAttachment.id
       );
       attach2.push(updatedAttachment);

--- a/src/app/state-management/reducers/published-data.reducer.spec.ts
+++ b/src/app/state-management/reducers/published-data.reducer.spec.ts
@@ -99,7 +99,7 @@ describe("PublishedData Reducer", () => {
 
   describe("UpdatePublishedData", () => {
     xit("should ...", () => {
-      let update: Update<PublishedData> = null;
+      const update: Update<PublishedData> = null;
       const payload = {
         publishedData: update
       };
@@ -110,7 +110,7 @@ describe("PublishedData Reducer", () => {
 
   describe("UpdatePublishedDatas", () => {
     it("should return the initial state", () => {
-      let updates: Update<PublishedData>[] = [];
+      const updates: Update<PublishedData>[] = [];
       const payload = {
         publishedDatas: updates
       };

--- a/src/app/state-management/reducers/samples.reducer.ts
+++ b/src/app/state-management/reducers/samples.reducer.ts
@@ -217,7 +217,7 @@ export function samplesReducer(
       const updatedAttachment = (action as UpdateAttachmentCaptionCompleteAction)
         .attachment;
       const attachments = state.currentSample.attachments;
-      let attach2 = attachments.filter(
+      const attach2 = attachments.filter(
         attachment => attachment.id !== updatedAttachment.id
       );
       attach2.push(updatedAttachment);

--- a/src/app/state-management/selectors/datasets.selectors.ts
+++ b/src/app/state-management/selectors/datasets.selectors.ts
@@ -68,7 +68,7 @@ export const getRectangularRepresentation = createSelector(
     }));
 
     const empty = Object.keys(merged).reduce(
-      (empty, key) => ({ [key]: "", ...empty }),
+      (empties, key) => ({ [key]: "", ...empties }),
       {}
     );
 

--- a/src/app/state-management/selectors/policies.selectors.ts
+++ b/src/app/state-management/selectors/policies.selectors.ts
@@ -51,7 +51,7 @@ export const getTotalCount = createSelector(
 export const getEditableCount = createSelector(
   getPolicyState,
   state => state.editableCount
-)
+);
 
 export const getFilters = createSelector(
   getPolicyState,

--- a/src/app/users/user-settings/user-settings.component.ts
+++ b/src/app/users/user-settings/user-settings.component.ts
@@ -110,7 +110,7 @@ export class UserSettingsComponent implements OnInit, OnDestroy {
   }
 
   onCopy(token: string) {
-    let selectionBox = this.document.createElement("textarea");
+    const selectionBox = this.document.createElement("textarea");
     selectionBox.style.position = "fixed";
     selectionBox.style.left = "0";
     selectionBox.style.top = "0";

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -5,9 +5,9 @@
 
 export const environment = {
   production: true,
-  lbBaseURL: 'https://dacat-development.psi.ch',
+  lbBaseURL: "https://dacat-development.psi.ch",
   archiveWorkflowEnabled: true,
-  externalAuthEndpoint: '/auth/msad',
+  externalAuthEndpoint: "/auth/msad",
   editMetadataEnabled: true,
   editSampleEnabled: true,
   scienceSearchEnabled: true,

--- a/src/environments/environment.maxiv.prod.ts
+++ b/src/environments/environment.maxiv.prod.ts
@@ -1,9 +1,9 @@
 export const environment = {
   production: true,
-  lbBaseURL: 'http://scicat.maxiv.lu.se',
-  externalAuthEndpoint: '/auth/msad',
+  lbBaseURL: "http://scicat.maxiv.lu.se",
+  externalAuthEndpoint: "/auth/msad",
   archiveWorkflowEnabled: false,
-  disabledDatasetColumns: ['select', 'archiveStatus', 'retrieveStatus', 'ownerGroup'],
-  facility: 'MAX IV',
+  disabledDatasetColumns: ["select", "archiveStatus", "retrieveStatus", "ownerGroup"],
+  facility: "MAX IV",
   shoppingCartEnabled: false
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,7 +1,7 @@
 export const environment = {
   production: true,
-  lbBaseURL: 'https://dacat.psi.ch',
-  externalAuthEndpoint: '/auth/msad',
+  lbBaseURL: "https://dacat.psi.ch",
+  externalAuthEndpoint: "/auth/msad",
   archiveWorkflowEnabled: true,
   editMetadataEnabled: false,
   editSampleEnabled: false,

--- a/src/environments/environment.qa.ts
+++ b/src/environments/environment.qa.ts
@@ -1,8 +1,8 @@
 export const environment = {
   production: true,
-  lbBaseURL: 'https://dacat-qa.psi.ch',
+  lbBaseURL: "https://dacat-qa.psi.ch",
   archiveWorkflowEnabled: true,
-  externalAuthEndpoint: '/auth/msad',
+  externalAuthEndpoint: "/auth/msad",
   editMetadataEnabled: true,
   editSampleEnabled: true,
   scienceSearchEnabled: true,

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -1,9 +1,9 @@
 export const environment = {
   production: true,
-  lbBaseURL: 'https://dacat-staging.psi.ch',
+  lbBaseURL: "https://dacat-staging.psi.ch",
   archiveWorkflowEnabled: true,
-  externalAuthEndpoint: '/auth/msad',
-  facility: 'PSI',
+  externalAuthEndpoint: "/auth/msad",
+  facility: "PSI",
   disabledDatasetColumns: [],
   shoppingCartEnabled: false
 };

--- a/tslint.json
+++ b/tslint.json
@@ -24,6 +24,8 @@
     "no-console": [true, "debug", "info", "time", "timeEnd", "trace"],
     "no-construct": true,
     "no-debugger": true,
+    "no-duplicate-imports": true,
+    "no-duplicate-switch-case": true,
     "no-duplicate-variable": true,
     "no-empty": false,
     "no-empty-interface": true,
@@ -49,6 +51,7 @@
     "quotemark": [true, "double"],
     "radix": true,
     "semicolon": true,
+    "switch-default": true,
     "triple-equals": [true, "allow-null-check"],
     "typedef-whitespace": [
       true,


### PR DESCRIPTION
## Description

Added new linting rules for tslint and linted project

## Motivation

Clean up project

## Changes:

* Added linting rule for catching multiple imports
* Added linting rule for catching switch statements without default
* Added linting rule for catching duplicate cases in switch statements

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

