### PR TITLE
Replaced /deep/ with ::ng-deep

### DIFF
--- a/src/app/datasets/dataset-table/dataset-table.component.scss
+++ b/src/app/datasets/dataset-table/dataset-table.component.scss
@@ -139,17 +139,17 @@
   }
 }
 
-:host /deep/ .disabled-row {
+:host ::ng-deep .disabled-row {
   pointer-events: none;
   opacity: 0.2 !important;
 }
 
-:host /deep/ .mat-row:hover {
+:host ::ng-deep .mat-row:hover {
   background-color: rgba(0, 0, 0, 0.1);
   cursor: pointer;
 }
 
-:host /deep/ .mat-paginator {
+:host ::ng-deep .mat-paginator {
   background-color: unset !important;
 }
 

--- a/src/app/logbooks/logbooks-table/logbooks-table.component.scss
+++ b/src/app/logbooks/logbooks-table/logbooks-table.component.scss
@@ -46,12 +46,12 @@
   }
 }
 
-:host /deep/ .disabled-row {
+:host ::ng-deep .disabled-row {
   pointer-events: none;
   opacity: 0.2 !important;
 }
 
-:host /deep/ .mat-row:hover {
+:host ::ng-deep .mat-row:hover {
   background-color: rgba(0, 0, 0, 0.1);
   cursor: pointer;
 }


### PR DESCRIPTION
## Description

Replaced scss `/deep/` with `::ng-deep`

## Motivation

`/deep/` has been marked as deprecated due to angular-cli switching from node-sass to dart-sass as of angular 8

## Changes:

* Replaced `/deep/` with `::ng-deep` in dataset table component
* Replaced `/deep/` with `::ng-deep` in logbooks table component

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

