### PR TITLE
Separated queries in login service into different user effects

### DIFF
--- a/src/app/state-management/actions/user.actions.ts
+++ b/src/app/state-management/actions/user.actions.ts
@@ -10,7 +10,8 @@ export const LOGOUT = "[User] Logout";
 export const LOGOUT_COMPLETE = "[User] Logout Complete";
 
 export const AD_LOGIN = "[User] Active Directory Login";
-export const AD_LOGIN_COMPLETE = "[User] Active Directory Login Complete";
+export const AD_LOGIN_SUCCESS = "[User] Active Directory Login Success";
+export const AD_LOGIN_FAILED = "[User] Active Directory Login Failed";
 
 export const RETRIEVE_USER = "[User] Retrieve User";
 export const RETRIEVE_USER_COMPLETE = "[User] Retrieve User Complete";
@@ -46,15 +47,29 @@ export const DESELECT_COLUMN = "[User] Deselect Column";
 export const DESELECT_COLUMN_COMPLETE = "[User] Deselect Column Complete";
 export const DESELECT_COLUMN_FAILED = "[User] Deselect Column Failed";
 
-export class LoginAction implements Action {
-  readonly type = LOGIN;
+export class ActiveDirLoginAction implements Action {
+  readonly type = AD_LOGIN;
   constructor(
     public form: { username: string; password: string; rememberMe: boolean }
   ) {}
 }
 
-export class ActiveDirLoginAction implements Action {
-  readonly type = AD_LOGIN;
+export class ActiveDirLoginSuccessAction implements Action {
+  readonly type = AD_LOGIN_SUCCESS;
+  constructor(readonly response: any) {}
+}
+
+export class ActiveDirLoginFailedAction implements Action {
+  readonly type = AD_LOGIN_FAILED;
+  constructor(
+    readonly username: string,
+    readonly password: string,
+    readonly rememberMe: boolean
+  ) {}
+}
+
+export class LoginAction implements Action {
+  readonly type = LOGIN;
   constructor(
     public form: { username: string; password: string; rememberMe: boolean }
   ) {}

--- a/src/app/state-management/reducers/user.reducer.ts
+++ b/src/app/state-management/reducers/user.reducer.ts
@@ -24,7 +24,8 @@ import {
   RETRIEVE_USER_IDENTITY_COMPLETE,
   RetrieveUserIdentCompleteAction,
   FETCH_CATAMEL_TOKEN_COMPLETE,
-  FetchCatamelTokenCompleteAction
+  FetchCatamelTokenCompleteAction,
+  AD_LOGIN
 } from "state-management/actions/user.actions";
 
 export function userReducer(
@@ -36,6 +37,10 @@ export function userReducer(
   }
 
   switch (action.type) {
+    case AD_LOGIN: {
+      return { ...state, isLoggingIn: true };
+    }
+
     case RETRIEVE_USER_COMPLETE: {
       const currentUser = (action as RetrieveUserCompleteAction).user;
       const isLoggedIn = true;

--- a/src/app/users/adauth.service.ts
+++ b/src/app/users/adauth.service.ts
@@ -18,7 +18,7 @@ export interface AccessToken {
 @Injectable()
 export class ADAuthService {
   constructor(
-    public http: HttpClient,
+    private http: HttpClient,
     @Inject(APP_CONFIG) private config: AppConfig
   ) {}
 

--- a/src/app/users/login/login.component.ts
+++ b/src/app/users/login/login.component.ts
@@ -104,6 +104,6 @@ export class LoginComponent implements OnInit, OnDestroy {
    */
   onLogin(event) {
     const form: LoginForm = this.loginForm.value;
-    this.store.dispatch(new ua.LoginAction(form));
+    this.store.dispatch(new ua.ActiveDirLoginAction(form));
   }
 }


### PR DESCRIPTION
## Description

Fix for login issue on scitest which makes sure that the different login request are dispatched in order

## Motivation

Login on scitest broken due to race conditions between ad login and functional login

## Changes:

* Broke out adLogin$ from login service into its own user effect
* Broke out funcLogin$ from login service into its own user effect

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

