### PR TITLE
Moved sample datasets to table in separate tab

### DIFF
--- a/src/app/samples/sample-detail/sample-detail.component.html
+++ b/src/app/samples/sample-detail/sample-detail.component.html
@@ -1,62 +1,71 @@
-<div class="sample-detail" *ngIf="sample$ | async as sample">
-  <mat-card class="scicat-card">
-    <mat-card-header>
-      Sample Details
-    </mat-card-header>
-    <div class="details">
-      <table>
-        <tr *ngIf="sample.description as value">
-          <th><i class="material-icons"> description </i>Description</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="sample.createdAt as value">
-          <th><i class="material-icons"> event </i>Creation Time</th>
-          <td>{{ value | date: "yyyy-MM-dd HH:mm" }}</td>
-        </tr>
-        <tr *ngIf="sample.owner as value">
-          <th><i class="material-icons"> person </i>Sample Owner</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="sample.ownerGroup as value">
-          <th><i class="material-icons"> group </i>Owner Group</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="sample.sampleId as value">
-          <th><i class="material-icons"> fingerprint </i>Sample ID</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr
-          *ngIf="
-            (datasets$ | async).length > 0 && datasets$ | async as datasets
-          "
-        >
-          <th><i class="material-icons"> save </i>Datasets</th>
-          <td>
-            <ul>
-              <li *ngFor="let value of datasets">
-                <a
-                  class="dropdown-item btn-sm"
-                  (click)="onClickDataset(value.pid)"
-                  >{{ value.pid }}</a
-                >
-              </li>
-            </ul>
-          </td>
-        </tr>
-      </table>
+<div *ngIf="sample">
+  <mat-tab-group>
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <mat-icon> details </mat-icon> Details
+      </ng-template>
 
-      <div *ngIf="sample.sampleCharacteristics as value">
-        <h3>Sample Characteristics</h3>
-        <pre>{{ value | json }}</pre>
+      <mat-card>
+        <mat-card-header>
+          Sample Details
+        </mat-card-header>
+        <div class="details">
+          <table>
+            <tr *ngIf="sample.description as value">
+              <th><i class="material-icons"> description </i>Description</th>
+              <td>{{ value }}</td>
+            </tr>
+            <tr *ngIf="sample.createdAt as value">
+              <th><i class="material-icons"> event </i>Creation Time</th>
+              <td>{{ value | date: "yyyy-MM-dd HH:mm" }}</td>
+            </tr>
+            <tr *ngIf="sample.owner as value">
+              <th><i class="material-icons"> person </i>Sample Owner</th>
+              <td>{{ value }}</td>
+            </tr>
+            <tr *ngIf="sample.ownerGroup as value">
+              <th><i class="material-icons"> group </i>Owner Group</th>
+              <td>{{ value }}</td>
+            </tr>
+            <tr *ngIf="sample.sampleId as value">
+              <th><i class="material-icons"> fingerprint </i>Sample ID</th>
+              <td>{{ value }}</td>
+            </tr>
+          </table>
+
+          <div *ngIf="sample.sampleCharacteristics as value">
+            <h3>Sample Characteristics</h3>
+            <pre>{{ value | json }}</pre>
+          </div>
+        </div>
+
+        <button mat-stroked-button (click)="show = !show">
+          {{ show ? "Hide MetaData" : "Show Metadata" }}
+        </button>
+        <br />
+        <div *ngIf="show">
+          <ngx-json-viewer [json]="sample" [expanded]="false"></ngx-json-viewer>
+        </div>
+      </mat-card>
+    </mat-tab>
+
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <mat-icon> folder </mat-icon> Datasets
+      </ng-template>
+
+      <div class="datasets-table">
+        <app-table
+          [data]="tableData"
+          [columns]="tableColumns"
+          [paginate]="tablePaginate"
+          [currentPage]="datasetsPage$ | async"
+          [dataCount]="datasetsCount$ | async"
+          [dataPerPage]="datasetsPerPage$ | async"
+          (pageChange)="onPageChange($event)"
+          (rowClick)="onRowClick($event)"
+        ></app-table>
       </div>
-    </div>
-
-    <button (click)="show = !show">
-      {{ show ? "Hide MetaData" : "Show Metadata" }}
-    </button>
-    <br />
-    <div *ngIf="show">
-      <ngx-json-viewer [json]="sample" [expanded]="false"></ngx-json-viewer>
-    </div>
-  </mat-card>
+    </mat-tab>
+  </mat-tab-group>
 </div>

--- a/src/app/samples/sample-detail/sample-detail.component.scss
+++ b/src/app/samples/sample-detail/sample-detail.component.scss
@@ -1,35 +1,40 @@
-.sample-detail .details {
-  padding: 1em;
+mat-card {
+  margin: 1em;
 
-  table {
-    tr {
-      td {
-        padding: 0.9em;
-        vertical-align: middle;
-      }
+  .mat-card-header {
+    background-color: #7de1ff;
+  }
+  .details {
+    padding: 1em;
 
-      th {
-        text-align: left;
-        padding-right: 0.5em;
-        material-icons {
+    table {
+      tr {
+        th {
+          text-align: left;
+          padding-right: 0.5em;
+          material-icons {
+            vertical-align: middle;
+          }
+        }
+
+        td {
+          padding: 0.9em;
           vertical-align: middle;
         }
       }
     }
-  }
 
-  h3 {
-    margin-top: 1em;
+    h3 {
+      margin-top: 1em;
+    }
+
+    .material-icons {
+      vertical-align: middle;
+      color: black;
+    }
   }
 }
 
-.mat-card-header {
-  background-color: #7de1ff;
-}
-
-
-
-.material-icons {
-	vertical-align: middle;
-	color: black;
+.datasets-table {
+  margin: 1em;
 }

--- a/src/app/samples/sample-detail/sample-detail.component.spec.ts
+++ b/src/app/samples/sample-detail/sample-detail.component.spec.ts
@@ -1,15 +1,36 @@
 import { ActivatedRoute, Router } from "@angular/router";
 import { HttpClient } from "@angular/common/http";
-import { MatCardModule } from "@angular/material";
+import {
+  MatCardModule,
+  MatTabsModule,
+  MatButtonModule,
+  MatIconModule
+} from "@angular/material";
 import {
   MockActivatedRoute,
   MockHttp,
   MockStore
 } from "../../shared/MockStubs";
 import { SampleDetailComponent } from "./sample-detail.component";
-import { Store } from "@ngrx/store";
-import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { Store, StoreModule } from "@ngrx/store";
+import {
+  async,
+  ComponentFixture,
+  TestBed,
+  inject
+} from "@angular/core/testing";
 import { NgxJsonViewerModule } from "ngx-json-viewer";
+import { rootReducer } from "state-management/reducers/root.reducer";
+import { PageChangeEvent } from "shared/modules/table/table.component";
+import {
+  changeDatasetsPageAction,
+  fetchSampleDatasetsAction
+} from "state-management/actions/samples.actions";
+import { Dataset, Sample } from "shared/sdk";
+import { SharedCatanieModule } from "shared/shared.module";
+import { DatePipe, SlicePipe } from "@angular/common";
+import { FileSizePipe } from "shared/pipes/filesize.pipe";
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 
 describe("SampleDetailComponent", () => {
   let component: SampleDetailComponent;
@@ -18,19 +39,30 @@ describe("SampleDetailComponent", () => {
   const router = {
     navigateByUrl: jasmine.createSpy("navigateByUrl")
   };
+  let store: MockStore;
+  let dispatchSpy;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [SampleDetailComponent],
-      imports: [MatCardModule, NgxJsonViewerModule]
+      imports: [
+        BrowserAnimationsModule,
+        MatButtonModule,
+        MatCardModule,
+        MatIconModule,
+        MatTabsModule,
+        NgxJsonViewerModule,
+        SharedCatanieModule,
+        StoreModule.forRoot({ rootReducer })
+      ],
+      providers: [DatePipe, FileSizePipe, SlicePipe]
     });
     TestBed.overrideComponent(SampleDetailComponent, {
       set: {
         providers: [
           { provide: HttpClient, useClass: MockHttp },
           { provide: Router, useValue: router },
-          { provide: ActivatedRoute, useClass: MockActivatedRoute },
-          { provide: Store, useClass: MockStore }
+          { provide: ActivatedRoute, useClass: MockActivatedRoute }
         ]
       }
     });
@@ -43,19 +75,71 @@ describe("SampleDetailComponent", () => {
     fixture.detectChanges();
   });
 
+  beforeEach(inject([Store], (mockStore: MockStore) => {
+    store = mockStore;
+  }));
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
   it("should create", () => {
     expect(component).toBeTruthy();
   });
 
-  describe("#onClickDataset()", () => {
-    it("should navigate to a dataset", () => {
-      const datasetId = "testId";
+  describe("#formatTableData()", () => {
+    it("should do nothing if there are no datasets", () => {
+      const data = component.formatTableData(null);
 
-      component.onClickDataset(datasetId);
+      expect(data).toBeUndefined();
+    });
+
+    it("should return an array of data objects if there are datasets", () => {
+      const datasets = [new Dataset()];
+      const data = component.formatTableData(datasets);
+
+      expect(data.length).toEqual(1);
+    });
+  });
+
+  describe("#onPageChange()", () => {
+    it("should dispatch a changeDatasetsPageAction and a fetchSampleDatasetsAction", () => {
+      dispatchSpy = spyOn(store, "dispatch");
+
+      const sample = new Sample();
+      sample.sampleId = "testId";
+      component.sample = sample;
+      const event: PageChangeEvent = {
+        pageIndex: 1,
+        pageSize: 25,
+        length: 25
+      };
+
+      component.onPageChange(event);
+
+      expect(dispatchSpy).toHaveBeenCalledTimes(2);
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        changeDatasetsPageAction({
+          page: event.pageIndex,
+          limit: event.pageSize
+        })
+      );
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        fetchSampleDatasetsAction({ sampleId: sample.sampleId })
+      );
+    });
+  });
+
+  describe("#onRowClick()", () => {
+    it("should navigate to a dataset", () => {
+      const dataset = new Dataset();
+      dataset.pid = "testId";
+
+      component.onRowClick(dataset);
 
       expect(router.navigateByUrl).toHaveBeenCalledTimes(1);
       expect(router.navigateByUrl).toHaveBeenCalledWith(
-        "/datasets/" + datasetId
+        "/datasets/" + dataset.pid
       );
     });
   });

--- a/src/app/samples/samples.module.ts
+++ b/src/app/samples/samples.module.ts
@@ -5,7 +5,8 @@ import {
   MatFormFieldModule,
   MatIconModule,
   MatInputModule,
-  MatButtonModule
+  MatButtonModule,
+  MatTabsModule
 } from "@angular/material";
 import { NgModule } from "@angular/core";
 import { SampleDetailComponent } from "./sample-detail/sample-detail.component";
@@ -31,6 +32,7 @@ import { TableModule } from "shared/modules/table/table.module";
     MatFormFieldModule,
     MatInputModule,
     MatDialogModule,
+    MatTabsModule,
     NgxJsonViewerModule,
     ReactiveFormsModule,
     SearchBarModule,

--- a/src/app/state-management/actions/samples.actions.spec.ts
+++ b/src/app/state-management/actions/samples.actions.spec.ts
@@ -81,7 +81,7 @@ describe("Sample Actions", () => {
       const sampleId = "testId";
       const action = fromActions.fetchSampleDatasetsAction({ sampleId });
       expect({ ...action }).toEqual({
-        type: "[Sample] Fetch Sample Datasets",
+        type: "[Sample] Fetch Datasets",
         sampleId
       });
     });
@@ -94,7 +94,7 @@ describe("Sample Actions", () => {
         datasets
       });
       expect({ ...action }).toEqual({
-        type: "[Sample] Fetch Sample Datasets Complete",
+        type: "[Sample] Fetch Datasets Complete",
         datasets
       });
     });
@@ -104,7 +104,40 @@ describe("Sample Actions", () => {
     it("should create an action", () => {
       const action = fromActions.fetchSampleDatasetsFailedAction();
       expect({ ...action }).toEqual({
-        type: "[Sample] Fetch Sample Datasets Failed"
+        type: "[Sample] Fetch Datasets Failed"
+      });
+    });
+  });
+
+  describe("fetchSampleDatasetsCountAction", () => {
+    it("should create an action", () => {
+      const sampleId = "testId";
+      const action = fromActions.fetchSampleDatasetsCountAction({ sampleId });
+      expect({ ...action }).toEqual({
+        type: "[Sample] Fetch Datasets Count",
+        sampleId
+      });
+    });
+  });
+
+  describe("fetchSampleDatasetsCountCompleteAction", () => {
+    it("should create an action", () => {
+      const count = 100;
+      const action = fromActions.fetchSampleDatasetsCountCompleteAction({
+        count
+      });
+      expect({ ...action }).toEqual({
+        type: "[Sample] Fetch Datasets Count Complete",
+        count
+      });
+    });
+  });
+
+  describe("fetchSampleDatasetsCountFailedAction", () => {
+    it("should create an action", () => {
+      const action = fromActions.fetchSampleDatasetsCountFailedAction();
+      expect({ ...action }).toEqual({
+        type: "[Sample] Fetch Datasets Count Failed"
       });
     });
   });
@@ -255,6 +288,19 @@ describe("Sample Actions", () => {
       const action = fromActions.changePageAction({ page, limit });
       expect({ ...action }).toEqual({
         type: "[Sample] Change Page",
+        page,
+        limit
+      });
+    });
+  });
+
+  describe("changeDatasetsPageAction", () => {
+    it("should create an action", () => {
+      const page = 1;
+      const limit = 25;
+      const action = fromActions.changeDatasetsPageAction({ page, limit });
+      expect({ ...action }).toEqual({
+        type: "[Sample] Change Datasets Page",
         page,
         limit
       });

--- a/src/app/state-management/actions/samples.actions.ts
+++ b/src/app/state-management/actions/samples.actions.ts
@@ -31,15 +31,27 @@ export const fetchSampleFailedAction = createAction(
 );
 
 export const fetchSampleDatasetsAction = createAction(
-  "[Sample] Fetch Sample Datasets",
+  "[Sample] Fetch Datasets",
   props<{ sampleId: string }>()
 );
 export const fetchSampleDatasetsCompleteAction = createAction(
-  "[Sample] Fetch Sample Datasets Complete",
+  "[Sample] Fetch Datasets Complete",
   props<{ datasets: Dataset[] }>()
 );
 export const fetchSampleDatasetsFailedAction = createAction(
-  "[Sample] Fetch Sample Datasets Failed"
+  "[Sample] Fetch Datasets Failed"
+);
+
+export const fetchSampleDatasetsCountAction = createAction(
+  "[Sample] Fetch Datasets Count",
+  props<{ sampleId: string }>()
+);
+export const fetchSampleDatasetsCountCompleteAction = createAction(
+  "[Sample] Fetch Datasets Count Complete",
+  props<{ count: number }>()
+);
+export const fetchSampleDatasetsCountFailedAction = createAction(
+  "[Sample] Fetch Datasets Count Failed"
 );
 
 export const addSampleAction = createAction(
@@ -90,6 +102,11 @@ export const removeAttachmentFailedAction = createAction(
 
 export const changePageAction = createAction(
   "[Sample] Change Page",
+  props<{ page: number; limit: number }>()
+);
+
+export const changeDatasetsPageAction = createAction(
+  "[Sample] Change Datasets Page",
   props<{ page: number; limit: number }>()
 );
 

--- a/src/app/state-management/effects/samples.effects.spec.ts
+++ b/src/app/state-management/effects/samples.effects.spec.ts
@@ -11,7 +11,10 @@ import {
 import { TestBed } from "@angular/core/testing";
 import { provideMockActions } from "@ngrx/effects/testing";
 import { provideMockStore } from "@ngrx/store/testing";
-import { getFullqueryParams } from "state-management/selectors/samples.selectors";
+import {
+  getFullqueryParams,
+  getDatasetsQueryParams
+} from "state-management/selectors/samples.selectors";
 import * as fromActions from "state-management/actions/samples.actions";
 import { hot, cold } from "jasmine-marbles";
 
@@ -33,7 +36,10 @@ describe("SampleEffects", () => {
         SampleEffects,
         provideMockActions(() => actions),
         provideMockStore({
-          selectors: [{ selector: getFullqueryParams, value: {} }]
+          selectors: [
+            { selector: getFullqueryParams, value: {} },
+            { selector: getDatasetsQueryParams, value: {} }
+          ]
         }),
         {
           provide: SampleApi,
@@ -145,18 +151,19 @@ describe("SampleEffects", () => {
   describe("fetchSampleDatasets$", () => {
     const sampleId = "testId";
 
-    it("should result in a fetchSampleDatasetsCompleteAction", () => {
+    it("should result in a fetchSampleDatasetsCompleteAction and a fetchSampleDatasetsCountAction", () => {
       const datasets = [new Dataset()];
       const action = fromActions.fetchSampleDatasetsAction({ sampleId });
-      const outcome = fromActions.fetchSampleDatasetsCompleteAction({
+      const outcome1 = fromActions.fetchSampleDatasetsCompleteAction({
         datasets
       });
+      const outcome2 = fromActions.fetchSampleDatasetsCountAction({ sampleId });
 
       actions = hot("-a", { a: action });
       const response = cold("-a|", { a: datasets });
       datasetApi.find.and.returnValue(response);
 
-      const expected = cold("--b", { b: outcome });
+      const expected = cold("--(bc)", { b: outcome1, c: outcome2 });
       expect(effects.fetchSampleDatasets$).toBeObservable(expected);
     });
 
@@ -170,6 +177,38 @@ describe("SampleEffects", () => {
 
       const expected = cold("--b", { b: outcome });
       expect(effects.fetchSampleDatasets$).toBeObservable(expected);
+    });
+  });
+
+  describe("fetchSampleDatasetsCount$", () => {
+    const sampleId = "testId";
+
+    it("should result in a fetchSampleDatasetsCountCompleteAction", () => {
+      const count = 1;
+      const datasets = [new Dataset()];
+      const action = fromActions.fetchSampleDatasetsCountAction({ sampleId });
+      const outcome = fromActions.fetchSampleDatasetsCountCompleteAction({
+        count
+      });
+
+      actions = hot("-a", { a: action });
+      const response = cold("-a|", { a: datasets });
+      datasetApi.find.and.returnValue(response);
+
+      const expected = cold("--b", { b: outcome });
+      expect(effects.fetchSampleDatasetsCount$).toBeObservable(expected);
+    });
+
+    it("should result in a fetchSampleDatasetsCountFailedAction", () => {
+      const action = fromActions.fetchSampleDatasetsCountAction({ sampleId });
+      const outcome = fromActions.fetchSampleDatasetsCountFailedAction();
+
+      actions = hot("-a", { a: action });
+      const response = cold("-#", {});
+      datasetApi.find.and.returnValue(response);
+
+      const expected = cold("--b", { b: outcome });
+      expect(effects.fetchSampleDatasetsCount$).toBeObservable(expected);
     });
   });
 

--- a/src/app/state-management/effects/samples.effects.ts
+++ b/src/app/state-management/effects/samples.effects.ts
@@ -2,7 +2,10 @@ import { Injectable } from "@angular/core";
 import { Actions, createEffect, ofType } from "@ngrx/effects";
 import { DatasetApi, SampleApi, Sample, Dataset } from "shared/sdk";
 import { Store, select } from "@ngrx/store";
-import { getFullqueryParams } from "state-management/selectors/samples.selectors";
+import {
+  getFullqueryParams,
+  getDatasetsQueryParams
+} from "state-management/selectors/samples.selectors";
 import * as fromActions from "state-management/actions/samples.actions";
 import {
   withLatestFrom,
@@ -16,6 +19,9 @@ import { of } from "rxjs";
 @Injectable()
 export class SampleEffects {
   private fullqueryParams$ = this.store.pipe(select(getFullqueryParams));
+  private datasetsQueryParams$ = this.store.pipe(
+    select(getDatasetsQueryParams)
+  );
 
   fetchSamples$ = createEffect(() =>
     this.actions$.pipe(
@@ -66,12 +72,32 @@ export class SampleEffects {
   fetchSampleDatasets$ = createEffect(() =>
     this.actions$.pipe(
       ofType(fromActions.fetchSampleDatasetsAction),
-      mergeMap(({ sampleId }) =>
-        this.datasetApi.find({ where: { sampleId } }).pipe(
-          map((datasets: Dataset[]) =>
-            fromActions.fetchSampleDatasetsCompleteAction({ datasets })
-          ),
+      withLatestFrom(this.datasetsQueryParams$),
+      mergeMap(([{ sampleId }, { order, skip, limit }]) =>
+        this.datasetApi.find({ where: { sampleId }, order, skip, limit }).pipe(
+          mergeMap((datasets: Dataset[]) => [
+            fromActions.fetchSampleDatasetsCompleteAction({ datasets }),
+            fromActions.fetchSampleDatasetsCountAction({ sampleId })
+          ]),
           catchError(() => of(fromActions.fetchSampleDatasetsFailedAction()))
+        )
+      )
+    )
+  );
+
+  fetchSampleDatasetsCount$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(fromActions.fetchSampleDatasetsCountAction),
+      switchMap(({ sampleId }) =>
+        this.datasetApi.find({ where: { sampleId } }).pipe(
+          map(datasets =>
+            fromActions.fetchSampleDatasetsCountCompleteAction({
+              count: datasets.length
+            })
+          ),
+          catchError(() =>
+            of(fromActions.fetchSampleDatasetsCountFailedAction())
+          )
         )
       )
     )

--- a/src/app/state-management/reducers/samples.reducer.spec.ts
+++ b/src/app/state-management/reducers/samples.reducer.spec.ts
@@ -16,13 +16,20 @@ const initialSampleState: SampleState = {
   currentSample: sample,
   datasets: [],
 
-  totalCount: 0,
+  samplesCount: 0,
+  datasetsCount: 0,
 
   isLoading: false,
 
-  filters: {
+  samplefilters: {
     text: "",
     sortField: "creationTime:desc",
+    skip: 0,
+    limit: 25
+  },
+  datasetFilters: {
+    text: "",
+    sortField: "createdAt:desc",
     skip: 0,
     limit: 25
   }
@@ -64,7 +71,7 @@ describe("SamplesReducer", () => {
       const action = fromActions.fetchSamplesCountCompleteAction({ count });
       const state = samplesReducer(initialSampleState, action);
 
-      expect(state.totalCount).toEqual(count);
+      expect(state.samplesCount).toEqual(count);
       expect(state.isLoading).toEqual(false);
     });
   });
@@ -133,6 +140,38 @@ describe("SamplesReducer", () => {
   describe("on fetchSampleDatasetsFailedAction", () => {
     it("should set isLoading to false", () => {
       const action = fromActions.fetchSampleDatasetsFailedAction();
+      const state = samplesReducer(initialSampleState, action);
+
+      expect(state.isLoading).toBe(false);
+    });
+  });
+
+  describe("on fetchSampleDatasetsCountAction", () => {
+    it("should set isLoading to true", () => {
+      const sampleId = "testId";
+      const action = fromActions.fetchSampleDatasetsCountAction({ sampleId });
+      const state = samplesReducer(initialSampleState, action);
+
+      expect(state.isLoading).toBe(true);
+    });
+  });
+
+  describe("on fetchSampleDatasetsCountCompleteAction", () => {
+    it("should set datasetsCount and set isLoading to false", () => {
+      const count = 100;
+      const action = fromActions.fetchSampleDatasetsCountCompleteAction({
+        count
+      });
+      const state = samplesReducer(initialSampleState, action);
+
+      expect(state.datasetsCount).toEqual(count);
+      expect(state.isLoading).toBe(false);
+    });
+  });
+
+  describe("on fetchSampleDatasetsCountFailedAction", () => {
+    it("should set isLoading to false", () => {
+      const action = fromActions.fetchSampleDatasetsCountFailedAction();
       const state = samplesReducer(initialSampleState, action);
 
       expect(state.isLoading).toBe(false);
@@ -275,38 +314,51 @@ describe("SamplesReducer", () => {
   });
 
   describe("on changePageAction", () => {
-    it("should set skip and limit filters", () => {
+    it("should set skip and limit sampleFilters", () => {
       const page = 2;
       const limit = 25;
       const skip = page * limit;
       const action = fromActions.changePageAction({ page, limit });
       const state = samplesReducer(initialSampleState, action);
 
-      expect(state.filters.limit).toEqual(limit);
-      expect(state.filters.skip).toEqual(skip);
+      expect(state.samplefilters.limit).toEqual(limit);
+      expect(state.samplefilters.skip).toEqual(skip);
+    });
+  });
+
+  describe("on changeDatasetsPageAction", () => {
+    it("should set skip and limit datasetFilters", () => {
+      const page = 2;
+      const limit = 25;
+      const skip = page * limit;
+      const action = fromActions.changeDatasetsPageAction({ page, limit });
+      const state = samplesReducer(initialSampleState, action);
+
+      expect(state.datasetFilters.limit).toEqual(limit);
+      expect(state.datasetFilters.skip).toEqual(skip);
     });
   });
 
   describe("on sortByColumnAction", () => {
-    it("should set sortField filter and set skip to 0", () => {
+    it("should set sortField sample filter and set skip to 0", () => {
       const column = "test";
       const direction = "asc";
       const sortField = column + (direction ? ":" + direction : "");
       const action = fromActions.sortByColumnAction({ column, direction });
       const state = samplesReducer(initialSampleState, action);
 
-      expect(state.filters.sortField).toEqual(sortField);
-      expect(state.filters.skip).toEqual(0);
+      expect(state.samplefilters.sortField).toEqual(sortField);
+      expect(state.samplefilters.skip).toEqual(0);
     });
   });
 
   describe("on setTextFilterAction", () => {
-    it("should set text filter", () => {
+    it("should set text sample filter", () => {
       const text = "test";
       const action = fromActions.setTextFilterAction({ text });
       const state = samplesReducer(initialSampleState, action);
 
-      expect(state.filters.text).toEqual(text);
+      expect(state.samplefilters.text).toEqual(text);
     });
   });
 });

--- a/src/app/state-management/reducers/samples.reducer.ts
+++ b/src/app/state-management/reducers/samples.reducer.ts
@@ -20,7 +20,7 @@ const reducer = createReducer(
 
   on(fromActions.fetchSamplesCountCompleteAction, (state, { count }) => ({
     ...state,
-    totalCount: count,
+    samplesCount: count,
     isLoading: false
   })),
   on(fromActions.fetchSamplesCountFailedAction, state => ({
@@ -49,6 +49,19 @@ const reducer = createReducer(
     isLoading: false
   })),
   on(fromActions.fetchSampleDatasetsFailedAction, state => ({
+    ...state,
+    isLoading: false
+  })),
+
+  on(fromActions.fetchSampleDatasetsCountAction, state => ({
+    ...state,
+    isLoading: true
+  })),
+  on(
+    fromActions.fetchSampleDatasetsCountCompleteAction,
+    (state, { count }) => ({ ...state, datasetsCount: count, isLoading: false })
+  ),
+  on(fromActions.fetchSampleDatasetsCountFailedAction, state => ({
     ...state,
     isLoading: false
   })),
@@ -123,17 +136,25 @@ const reducer = createReducer(
 
   on(fromActions.changePageAction, (state, { page, limit }) => {
     const skip = page * limit;
-    return { ...state, filters: { ...state.filters, skip, limit } };
+    const samplefilters = { ...state.samplefilters, skip, limit };
+    return { ...state, samplefilters };
+  }),
+
+  on(fromActions.changeDatasetsPageAction, (state, { page, limit }) => {
+    const skip = page * limit;
+    const datasetFilters = { ...state.datasetFilters, skip, limit };
+    return { ...state, datasetFilters };
   }),
 
   on(fromActions.sortByColumnAction, (state, { column, direction }) => {
     const sortField = column + (direction ? ":" + direction : "");
-    return { ...state, filters: { ...state.filters, sortField, skip: 0 } };
+    const samplefilters = { ...state.samplefilters, sortField, skip: 0 };
+    return { ...state, samplefilters };
   }),
 
   on(fromActions.setTextFilterAction, (state, { text }) => ({
     ...state,
-    filters: { ...state.filters, text }
+    samplefilters: { ...state.samplefilters, text }
   }))
 );
 

--- a/src/app/state-management/selectors/samples.selectors.spec.ts
+++ b/src/app/state-management/selectors/samples.selectors.spec.ts
@@ -14,13 +14,21 @@ const initialSampleState: SampleState = {
   currentSample: sample,
   datasets: [],
 
-  totalCount: 0,
+  samplesCount: 0,
+  datasetsCount: 0,
 
   isLoading: false,
 
-  filters: {
+  samplefilters: {
     text: "",
     sortField: "creationTime:desc",
+    skip: 0,
+    limit: 25
+  },
+
+  datasetFilters: {
+    text: "",
+    sortField: "createdAt:desc",
     skip: 0,
     limit: 25
   }
@@ -53,18 +61,26 @@ describe("Sample Selectors", () => {
     });
   });
 
-  describe("getSampleDatasets", () => {
+  describe("getDatasets", () => {
     it("should get the datasets related to the current sample", () => {
-      expect(
-        fromSelectors.getSampleDatasets.projector(initialSampleState)
-      ).toEqual([]);
+      expect(fromSelectors.getDatasets.projector(initialSampleState)).toEqual(
+        []
+      );
     });
   });
 
   describe("getSamplesCount", () => {
-    it("should get totalCount", () => {
+    it("should get samplesCount", () => {
       expect(
         fromSelectors.getSamplesCount.projector(initialSampleState)
+      ).toEqual(0);
+    });
+  });
+
+  describe("getDatasetsCount", () => {
+    it("should get datasetsCount", () => {
+      expect(
+        fromSelectors.getDatasetsCount.projector(initialSampleState)
       ).toEqual(0);
     });
   });
@@ -78,38 +94,84 @@ describe("Sample Selectors", () => {
   });
 
   describe("getFilters", () => {
-    it("should get the filters", () => {
+    it("should get sampleFilters", () => {
       expect(fromSelectors.getFilters.projector(initialSampleState)).toEqual(
-        initialSampleState.filters
+        initialSampleState.samplefilters
       );
+    });
+  });
+
+  describe("getDatasetFilters", () => {
+    it("should get datasetFilters", () => {
+      expect(
+        fromSelectors.getDatasetFilters.projector(initialSampleState)
+      ).toEqual(initialSampleState.datasetFilters);
     });
   });
 
   describe("getPage", () => {
     it("should get the current samples page", () => {
-      const { skip, limit } = initialSampleState.filters;
+      const { skip, limit } = initialSampleState.samplefilters;
       const page = skip / limit;
       expect(
-        fromSelectors.getPage.projector(initialSampleState.filters)
+        fromSelectors.getPage.projector(initialSampleState.samplefilters)
+      ).toEqual(page);
+    });
+  });
+
+  describe("getDatasetsPage", () => {
+    it("should get the current datasets page", () => {
+      const { skip, limit } = initialSampleState.datasetFilters;
+      const page = skip / limit;
+      expect(
+        fromSelectors.getDatasetsPage.projector(
+          initialSampleState.datasetFilters
+        )
       ).toEqual(page);
     });
   });
 
   describe("getSamplesPerPage", () => {
-    it("should get limit from filters", () => {
+    it("should get limit from sampleFilters", () => {
       expect(
-        fromSelectors.getSamplesPerPage.projector(initialSampleState.filters)
+        fromSelectors.getSamplesPerPage.projector(
+          initialSampleState.samplefilters
+        )
+      ).toEqual(25);
+    });
+  });
+
+  describe("getDatasetsPerPage", () => {
+    it("should get limit from datasetFilters", () => {
+      expect(
+        fromSelectors.getDatasetsPerPage.projector(
+          initialSampleState.datasetFilters
+        )
       ).toEqual(25);
     });
   });
 
   describe("getFullqueryParams", () => {
     it("should get the fullquery params", () => {
-      const { text, sortField, skip, limit } = initialSampleState.filters;
+      const { text, sortField, skip, limit } = initialSampleState.samplefilters;
       const limits = { order: sortField, skip, limit };
       const params = { query: JSON.stringify({ text }), limits };
       expect(
-        fromSelectors.getFullqueryParams.projector(initialSampleState.filters)
+        fromSelectors.getFullqueryParams.projector(
+          initialSampleState.samplefilters
+        )
+      ).toEqual(params);
+    });
+  });
+
+  describe("getDatasetsQueryParams", () => {
+    it("should get the datasets query params", () => {
+      const { sortField, skip, limit } = initialSampleState.datasetFilters;
+      const params = { order: sortField, skip, limit };
+      expect(
+        fromSelectors.getDatasetsQueryParams.projector(
+          initialSampleState.datasetFilters
+        )
       ).toEqual(params);
     });
   });

--- a/src/app/state-management/selectors/samples.selectors.ts
+++ b/src/app/state-management/selectors/samples.selectors.ts
@@ -18,14 +18,19 @@ export const getCurrentAttachments = createSelector(
   sample => sample.attachments
 );
 
-export const getSampleDatasets = createSelector(
+export const getDatasets = createSelector(
   getSampleState,
   state => state.datasets
 );
 
 export const getSamplesCount = createSelector(
   getSampleState,
-  state => state.totalCount
+  state => state.samplesCount
+);
+
+export const getDatasetsCount = createSelector(
+  getSampleState,
+  state => state.datasetsCount
 );
 
 export const getIsLoading = createSelector(
@@ -35,11 +40,24 @@ export const getIsLoading = createSelector(
 
 export const getFilters = createSelector(
   getSampleState,
-  state => state.filters
+  state => state.samplefilters
+);
+
+export const getDatasetFilters = createSelector(
+  getSampleState,
+  state => state.datasetFilters
 );
 
 export const getPage = createSelector(
   getFilters,
+  filters => {
+    const { skip, limit } = filters;
+    return skip / limit;
+  }
+);
+
+export const getDatasetsPage = createSelector(
+  getDatasetFilters,
   filters => {
     const { skip, limit } = filters;
     return skip / limit;
@@ -51,11 +69,24 @@ export const getSamplesPerPage = createSelector(
   filters => filters.limit
 );
 
+export const getDatasetsPerPage = createSelector(
+  getDatasetFilters,
+  filters => filters.limit
+);
+
 export const getFullqueryParams = createSelector(
   getFilters,
   filters => {
     const { text, sortField, skip, limit } = filters;
     const limits = { order: sortField, skip, limit };
     return { query: JSON.stringify({ text }), limits };
+  }
+);
+
+export const getDatasetsQueryParams = createSelector(
+  getDatasetFilters,
+  filters => {
+    const { sortField, skip, limit } = filters;
+    return { order: sortField, skip, limit };
   }
 );

--- a/src/app/state-management/state/samples.store.ts
+++ b/src/app/state-management/state/samples.store.ts
@@ -5,25 +5,36 @@ export interface SampleState {
   currentSample: Sample;
   datasets: Dataset[];
 
-  totalCount: number;
+  samplesCount: number;
+  datasetsCount: number;
 
   isLoading: boolean;
 
-  filters: SampleFilters;
+  samplefilters: SampleFilters;
+
+  datasetFilters: SampleFilters;
 }
 
 export const initialSampleState: SampleState = {
   samples: [],
-  datasets: [],
   currentSample: null,
+  datasets: [],
 
-  totalCount: 0,
+  samplesCount: 0,
+  datasetsCount: 0,
 
   isLoading: true,
 
-  filters: {
+  samplefilters: {
     text: "",
     sortField: "creationTime:desc",
+    skip: 0,
+    limit: 25
+  },
+
+  datasetFilters: {
+    text: "",
+    sortField: "createdAt:desc",
     skip: 0,
     limit: 25
   }


### PR DESCRIPTION
## Description

Moved sample datasets from list to table in separate tab

## Motivation

Consistent UI

## Changes:

* Added datasetFilters and datasetsCount properties to store
* Added actions for fetching dataset counts and table pagination
* Added effect for fetching datasets count
* Added reducers for new actions
* Added selector for datasets querying
* Added new tab containing shared table to sample details component

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

