### PR TITLE
remove unused datetime picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2781,11 +2781,6 @@
         }
       }
     },
-    "@ngui/datetime-picker": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@ngui/datetime-picker/-/datetime-picker-0.16.2.tgz",
-      "integrity": "sha1-fZAXAqD8yRUn2j+IPAheXtxNhBw="
-    },
     "@nodelib/fs.stat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@ngrx/router-store": "^8.3.0",
     "@ngrx/schematics": "^8.3.0",
     "@ngrx/store": "^8.3.0",
-    "@ngui/datetime-picker": "^0.16.2",
     "autolinker": "^3.11.1",
     "deep-equal": "^1.1.0",
     "filesize": "^5.0.1",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,7 +12,6 @@ import { FlexLayoutModule } from "@angular/flex-layout";
 import { HttpClientModule } from "@angular/common/http";
 import { JobEffects } from "state-management/effects/jobs.effects";
 import { NgModule } from "@angular/core";
-import { NguiDatetimePickerModule } from "@ngui/datetime-picker";
 import { PolicyEffects } from "state-management/effects/policies.effects";
 import { PoliciesModule } from "policies/policies.module";
 import { ProposalsModule } from "proposals/proposals.module";
@@ -75,7 +74,6 @@ import { JobsModule } from "jobs/jobs.module";
     MatProgressSpinnerModule,
     MatSnackBarModule,
     MatToolbarModule,
-    NguiDatetimePickerModule,
     PoliciesModule,
     ProposalsModule,
     PublisheddataModule,

--- a/src/app/users/user-settings/user-settings.component.spec.ts
+++ b/src/app/users/user-settings/user-settings.component.spec.ts
@@ -2,7 +2,6 @@ import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { ReactiveFormsModule } from "@angular/forms";
 import { Store } from "@ngrx/store";
-import { NguiDatetimePickerModule } from "@ngui/datetime-picker";
 import { MockConfigService, MockStore, MockUserApi } from "shared/MockStubs";
 import { UserApi } from "shared/sdk/services";
 import { ConfigService } from "../../shared/services";
@@ -19,7 +18,6 @@ describe("UserSettingsComponent", () => {
       schemas: [NO_ERRORS_SCHEMA],
       imports: [
         ReactiveFormsModule,
-        NguiDatetimePickerModule,
         SharedCatanieModule
       ],
       declarations: [UserSettingsComponent]


### PR DESCRIPTION
## Description

removing unused datetime picker

## Motivation

we are using sattimepicker and not ngui so the import is unneeded

## Fixes:

* Items added

## Changes:

* changes made

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

