### PR TITLE
Hotfix/datasets table filesize

### DIFF
--- a/src/app/datasets/dataset-table/dataset-table.component.html
+++ b/src/app/datasets/dataset-table/dataset-table.component.html
@@ -113,7 +113,7 @@
   </div>
 
   <mat-table
-    [dataSource]="datasets$"
+    [dataSource]="datasets"
     class="dataset-table mat-elevation-z2"
     matSort
     (matSortChange)="onSortChange($event)"
@@ -123,7 +123,11 @@
     <!-- Select Column -->
     <ng-container matColumnDef="select">
       <mat-header-cell *matHeaderCellDef>
-        <mat-checkbox color="#ffffff" (change)="onSelectAll($event)">
+        <mat-checkbox
+          [checked]="selectedSets.length > 0 && isAllSelected()"
+          [indeterminate]="selectedSets.length > 0 && !isAllSelected()"
+          (change)="onSelectAll($event)"
+        >
         </mat-checkbox>
       </mat-header-cell>
 
@@ -174,6 +178,7 @@
       </mat-cell>
     </ng-container>
 
+    <!-- Run Number Column -->
     <ng-container matColumnDef="runNumber">
       <mat-header-cell *matHeaderCellDef mat-sort-header>
         <div fxLayout="column" style="align-items: center">
@@ -400,44 +405,6 @@
           <i class="material-icons" style="color: black;">build</i>
           &nbsp;user error</ng-template
         >
-      </mat-cell>
-    </ng-container>
-
-    <!-- Archive Status Column -->
-    <ng-container matColumnDef="archiveStatus">
-      <mat-header-cell *matHeaderCellDef mat-sort-header>
-        <div fxLayout="column" style="align-items: center">
-          <div>
-            <i class="material-icons">archive</i>
-          </div>
-          <div class="table_column">Archive&nbsp;Status</div>
-        </div>
-      </mat-header-cell>
-      <mat-cell
-        *matCellDef="let dataset"
-        matTooltip="{{ (dataset.datasetlifecycle || {}).archiveStatusMessage }}"
-      >
-        {{ (dataset.datasetlifecycle || {}).archiveStatusMessage }}
-      </mat-cell>
-    </ng-container>
-
-    <!-- Retrieve Status Column -->
-    <ng-container matColumnDef="retrieveStatus">
-      <mat-header-cell *matHeaderCellDef mat-sort-header>
-        <div fxLayout="column" style="align-items: center">
-          <div>
-            <i class="material-icons">cloud_upload</i>
-          </div>
-          <div class="table_column">Retrieve&nbsp;Status</div>
-        </div>
-      </mat-header-cell>
-      <mat-cell
-        *matCellDef="let dataset"
-        matTooltip="{{
-          (dataset.datasetlifecycle || {}).retrieveStatusMessage
-        }}"
-      >
-        {{ (dataset.datasetlifecycle || {}).retrieveStatusMessage }}
       </mat-cell>
     </ng-container>
 

--- a/src/app/datasets/dataset-table/dataset-table.component.scss
+++ b/src/app/datasets/dataset-table/dataset-table.component.scss
@@ -19,124 +19,115 @@
 
   .tableSettings {
     margin-bottom: 0.5em;
-    color: #969696;
+    color: mat-color($grey, 100);
+
+    ::ng-deep .tblSettingSelect div.mat-select-arrow-wrapper {
+      display: none;
+    }
+
+    ::ng-deep .tblSettingSelect.mat-select {
+      display: inline;
+    }
   }
 
-  mat-header-cell {
-    color: white;
-    background: mat-color($primary);
-    justify-content: center;
+  mat-table {
+    overflow: scroll;
+
+    mat-header-row {
+      min-width: 1290px;
+      background: mat-color($primary);
+    }
+
+    ::ng-deep .mat-sort-header-arrow {
+      color: mat-color($primary, default-contrast);
+    }
+
+    mat-header-cell {
+      color: mat-color($primary, default-contrast);
+      justify-content: center;
+
+      ::ng-deep .mat-checkbox .mat-checkbox-frame {
+        border-color: mat-color($primary, default-contrast);
+      }
+    }
+
+    mat-header-cell:nth-child(-n + 2) {
+      justify-content: left;
+    }
+
+    mat-header-cell:nth-child(n + 3) {
+      justify-content: center;
+    }
+
+    mat-cell:nth-child(-n + 2) {
+      justify-content: left;
+    }
+
+    mat-cell:nth-child(n + 3) {
+      justify-content: center;
+    }
+
+    mat-row {
+      min-width: 1290px;
+    }
+
+    mat-row:hover {
+      background-color: rgba(0, 0, 0, 0.1);
+      cursor: pointer;
+    }
+
+    .mat-column-select {
+      min-width: 55px;
+      max-width: 55px;
+    }
+
+    .mat-column-datasetName {
+      min-width: 200px;
+    }
+
+    .mat-column-runNumber {
+      min-width: 70px;
+    }
+
+    .mat-column-sourceFolder {
+      min-width: 100px;
+    }
+
+    .mat-column-size {
+      min-width: 65px;
+    }
+
+    .mat-column-creationTime {
+      min-width: 80px;
+    }
+
+    .mat-column-type {
+      min-width: 50px;
+    }
+
+    .mat-column-image {
+      min-width: 60px;
+      max-width: 60px;
+    }
+
+    .mat-column-metadata {
+      min-width: 200px;
+    }
+
+    .mat-column-proposalId {
+      min-width: 90px;
+    }
+
+    .mat-column-ownerGroup {
+      min-width: 80px;
+    }
+
+    .mat-column-dataStatus {
+      min-width: 140px;
+    }
+
+    .mat-column-derivedDatasetsNum {
+      min-width: 100px;
+    }
   }
-
-  mat-header-row {
-    color: white;
-    background: mat-color($primary);
-  }
-
-  i {
-    color: white;
-  }
-
-  .mat-column-select {
-    overflow: visible; /* Needed to prevent offsetting of the checkbox when clicking */
-    flex-shrink: 0;
-    flex-grow: 0;
-    padding-right: 10px;
-  }
-
-  .mat-column-datasetName {
-    flex: 1 0 200px;
-    justify-content: left !important;
-  }
-
-  .mat-column-sourceFolder {
-    flex: 1 0 120px;
-    justify-content: center !important;
-  }
-
-  .mat-column-runNumber {
-    flex: 1 0 50px;
-    justify-content: center !important;
-  }
-
-  .mat-column-size {
-    flex: 1 0 50px;
-    justify-content: center !important;
-  }
-
-  .mat-column-creationTime {
-    flex: 1 0 80px;
-    justify-content: center !important;
-  }
-
-  .mat-column-type {
-    flex: 0 0 50px;
-    justify-content: center !important;
-  }
-
-  .mat-column-derivedDatasetsNum {
-    flex: 0 0 100px;
-    justify-content: center !important;
-  }
-
-  .mat-column-image {
-    flex: 0 0 60px;
-    justify-content: center !important;
-  }
-
-  .mat-column-metadata {
-    flex: 2 0 100px;
-    justify-content: center !important;
-  }
-
-  .mat-column-proposalId {
-    flex: 1 0 70px;
-    justify-content: center !important;
-  }
-
-  .mat-column-ownerGroup {
-    flex: 0 0 80px;
-    justify-content: center !important;
-  }
-
-  .mat-column-archiveStatus {
-    flex: 1 0 150px;
-    justify-content: center !important;
-  }
-
-  .mat-column-retrieveStatus {
-    flex: 1 0 130px;
-    justify-content: center !important;
-  }
-
-  .mat-column-dataStatus {
-    flex: 1 0 130px;
-    justify-content: center !important;
-  }
-}
-
-:host ::ng-deep .disabled-row {
-  pointer-events: none;
-  opacity: 0.2 !important;
-}
-
-:host ::ng-deep .mat-row:hover {
-  background-color: rgba(0, 0, 0, 0.1);
-  cursor: pointer;
-}
-
-:host ::ng-deep .mat-paginator {
-  background-color: unset !important;
-}
-
-::ng-deep mat-header-cell .mat-checkbox-frame {
-  border-color: white;
-}
-
-::ng-deep .tblSettingSelect div.mat-select-arrow-wrapper {
-  display: none;
-}
-
-::ng-deep .tblSettingSelect.mat-select {
-  display: inline;
 }

--- a/src/app/datasets/dataset-table/dataset-table.component.spec.ts
+++ b/src/app/datasets/dataset-table/dataset-table.component.spec.ts
@@ -426,6 +426,22 @@ describe("DatasetTableComponent", () => {
     });
   });
 
+  describe("#isAllSelected()", () => {
+    it("should return false if length of datasets and length of selectedSets are not equal", () => {
+      component.datasets = [new Dataset()];
+
+      const allSelected = component.isAllSelected();
+
+      expect(allSelected).toEqual(false);
+    });
+
+    it("should return true if length of datasets and length of selectedSets are equal", () => {
+      const allSelected = component.isAllSelected();
+
+      expect(allSelected).toEqual(true);
+    });
+  });
+
   describe("#isInBatch()", () => {
     it("should return false if dataset is not in batch", () => {
       const dataset = new Dataset();

--- a/src/app/datasets/dataset-table/dataset-table.component.ts
+++ b/src/app/datasets/dataset-table/dataset-table.component.ts
@@ -57,7 +57,7 @@ interface DatasetDerivationsMap {
   styleUrls: ["dataset-table.component.scss"]
 })
 export class DatasetTableComponent implements OnInit, OnDestroy {
-  datasets$ = this.store.pipe(select(getDatasets));
+  datasets: Dataset[];
   currentPage$ = this.store.pipe(select(getPage));
   datasetsPerPage$ = this.store.pipe(select(getDatasetsPerPage));
   datasetCount$ = this.store.select(getTotalSets);
@@ -250,6 +250,12 @@ export class DatasetTableComponent implements OnInit, OnDestroy {
     return this.selectedPids.indexOf(dataset.pid) !== -1;
   }
 
+  isAllSelected(): boolean {
+    const numSelected = this.selectedSets ? this.selectedSets.length : 0;
+    const numRows = this.datasets ? this.datasets.length : 0;
+    return numSelected === numRows;
+  }
+
   isInBatch(dataset: Dataset): boolean {
     return this.inBatchPids.indexOf(dataset.pid) !== -1;
   }
@@ -310,6 +316,12 @@ export class DatasetTableComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
+    this.subscriptions.push(
+      this.store.pipe(select(getDatasets)).subscribe(datasets => {
+        this.datasets = datasets;
+      })
+    );
+
     this.subscriptions.push(
       this.store.pipe(select(getSubmitError)).subscribe(err => {
         if (!err) {

--- a/src/app/datasets/dataset-table/dataset-table.component.ts
+++ b/src/app/datasets/dataset-table/dataset-table.component.ts
@@ -70,7 +70,7 @@ export class DatasetTableComponent implements OnInit, OnDestroy {
   displayedColumns: string[] = [];
 
   private selectedPids: string[] = [];
-  private selectedSets: Dataset[] = [];
+  selectedSets: Dataset[] = [];
   private inBatchPids: string[] = [];
 
   public currentArchViewMode: ArchViewMode;

--- a/src/app/shared/modules/table/table.component.ts
+++ b/src/app/shared/modules/table/table.component.ts
@@ -47,11 +47,11 @@ export class TableComponent implements OnInit {
   @Input() dataPerPage?: number;
   pageSizeOptions = [10, 25, 50, 100, 500, 1000];
 
-  @Output() pageChange ? = new EventEmitter<PageChangeEvent>();
-  @Output() sortChange ? = new EventEmitter<SortChangeEvent>();
-  @Output() rowClick ? = new EventEmitter<any>();
-  @Output() selectAll ? = new EventEmitter<MatCheckboxChange>();
-  @Output() selectOne ? = new EventEmitter<CheckboxEvent>();
+  @Output() pageChange = new EventEmitter<PageChangeEvent>();
+  @Output() sortChange = new EventEmitter<SortChangeEvent>();
+  @Output() rowClick = new EventEmitter<any>();
+  @Output() selectAll = new EventEmitter<MatCheckboxChange>();
+  @Output() selectOne = new EventEmitter<CheckboxEvent>();
 
   constructor() {}
 

--- a/src/app/state-management/effects/policies.effects.ts
+++ b/src/app/state-management/effects/policies.effects.ts
@@ -102,7 +102,7 @@ export class PolicyEffects {
           filter = {};
         } else {
           const email = profile.email.toLowerCase();
-          filter = { where: { manager: email } };
+          filter = { manager: email };
         }
         return this.policyApi.count(filter).pipe(
           map(({ count }) =>


### PR DESCRIPTION
## Description

Fixed datasets table column widths so that no text gets cut off, added side scroll, and fixed checkboxes

## Motivation

Requested

## Changes:

* Updated styling to use `min-width` for datasets table columns instead of `flex`
* Moved `justify-content` properties to general column classes to avoid repetetiveness
* Added `owerflow: scroll` property to table styling
* All colors are now retrieved from theme file
* Removed unused css
* Added `isAllSelected` method to datasets table component
* Added `indetereminate` and `checked` properties to 'select all' checkbox

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

