### PR TITLE
Feature/add custom keywords

### DIFF
--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -5,7 +5,7 @@
         About the data
       </mat-card-header>
 
-      <table>
+      <table class="about-table">
         <tr *ngIf="dataset.datasetName as value">
           <th><mat-icon> fingerprint </mat-icon> Name</th>
           <td>{{ value }}</td>
@@ -18,23 +18,6 @@
           <th><mat-icon> person </mat-icon> Owner</th>
           <td>{{ value }}</td>
         </tr>
-        <tr *ngIf="dataset.keywords as keywords">
-          <th><mat-icon> vpn_key </mat-icon> Keywords</th>
-          <td>
-            <mat-chip-list>
-              <div *ngIf="keywords.length > 0">
-                <span *ngFor="let keyword of keywords">
-                  <mat-chip (click)="onClickKeyword(keyword)">
-                    {{ keyword }}
-                  </mat-chip>
-                </span>
-              </div>
-              <div *ngIf="keywords.length === 0">
-                <mat-chip disabled>No Keywords</mat-chip>
-              </div>
-            </mat-chip-list>
-          </td>
-        </tr>
         <tr>
           <th><mat-icon> perm_contact_calendar </mat-icon> PID</th>
           <td>{{ dataset.pid }}</td>
@@ -42,6 +25,53 @@
         <tr *ngIf="dataset.sourceFolder as value">
           <th><mat-icon> folder </mat-icon> Source Folder</th>
           <td>{{ value }}</td>
+        </tr>
+        <tr class="keywords-row" *ngIf="dataset.keywords as keywords">
+          <th><mat-icon> vpn_key </mat-icon> Keywords</th>
+          <td *ngIf="!editEnabled">
+            <mat-chip-list *ngIf="keywords.length > 0" #keywordChips>
+              <mat-chip
+                *ngFor="let keyword of keywords"
+                [removable]="true"
+                (removed)="onRemoveKeyword(keyword)"
+                (click)="onClickKeyword(keyword)"
+              >
+                {{ keyword }}
+                <mat-icon matChipRemove>cancel</mat-icon>
+              </mat-chip>
+              <mat-chip class="add-keyword-chip" (click)="editEnabled = true">
+                Add Keyword <mat-icon>add</mat-icon>
+              </mat-chip>
+            </mat-chip-list>
+          </td>
+          <td *ngIf="editEnabled">
+            <mat-form-field>
+              <mat-chip-list *ngIf="keywords.length > 0" #keywordChips>
+                <mat-chip
+                  *ngFor="let keyword of keywords"
+                  [removable]="true"
+                  (removed)="onRemoveKeyword(keyword)"
+                  (click)="onClickKeyword(keyword)"
+                >
+                  {{ keyword }}
+                  <mat-icon matChipRemove>cancel</mat-icon>
+                </mat-chip>
+                <input
+                  [matChipInputFor]="keywordChips"
+                  [matChipInputSeparatorKeyCodes]="separatorKeyCodes"
+                  [matChipInputAddOnBlur]="true"
+                  (matChipInputTokenEnd)="onAddKeyword($event)"
+                />
+              </mat-chip-list>
+            </mat-form-field>
+            <button
+              mat-raised-button
+              class="done-edit-button"
+              (click)="editEnabled = false"
+            >
+              Done
+            </button>
+          </td>
         </tr>
       </table>
     </mat-card>

--- a/src/app/datasets/dataset-detail/dataset-detail.component.scss
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.scss
@@ -1,9 +1,16 @@
+@import "../../../theme.scss";
+
 mat-card {
   mat-icon {
     vertical-align: middle;
   }
 
   table {
+    th {
+      text-align: left;
+      padding-right: 0.5em;
+    }
+
     td {
       padding: 0.5em;
 
@@ -11,10 +18,31 @@ mat-card {
         cursor: pointer;
       }
     }
+  }
 
+  .about-table {
     th {
-      text-align: left;
-      padding-right: 0.5em;
+      min-width: 10em;
+    }
+
+    td {
+      width: 100%;
+    }
+
+    .keywords-row {
+      .add-keyword-chip:hover {
+        cursor: pointer;
+      }
+
+      mat-form-field {
+        width: 92%;
+      }
+
+      .done-edit-button {
+        margin-left: 1em;
+        background-color: mat-color($accent);
+        color: mat-color($accent, default-contrast);
+      }
     }
   }
 }

--- a/src/app/datasets/dataset-detail/dataset-detail.component.spec.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.spec.ts
@@ -5,7 +5,7 @@ import { LinkyPipe } from "ngx-linky";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { SharedCatanieModule } from "shared/shared.module";
-import { MatTableModule } from "@angular/material";
+import { MatTableModule, MatChipInputEvent } from "@angular/material";
 
 describe("DatasetDetailComponent", () => {
   let component: DatasetDetailComponent;
@@ -51,6 +51,43 @@ describe("DatasetDetailComponent", () => {
 
       expect(component.clickKeyword.emit).toHaveBeenCalledTimes(1);
       expect(component.clickKeyword.emit).toHaveBeenCalledWith(keyword);
+    });
+  });
+
+  describe("#onAddKeyword()", () => {
+    it("should not emit an event if value is an empty string", () => {
+      spyOn(component.addKeyword, "emit");
+
+      const event = {
+        value: ""
+      };
+      component.onAddKeyword(event as MatChipInputEvent);
+
+      expect(component.addKeyword.emit).toHaveBeenCalledTimes(0);
+    });
+
+    it("should emit an event if value is not an empty string", () => {
+      spyOn(component.addKeyword, "emit");
+
+      const event = {
+        value: "test"
+      };
+      component.onAddKeyword(event as MatChipInputEvent);
+
+      expect(component.addKeyword.emit).toHaveBeenCalledTimes(1);
+      expect(component.addKeyword.emit).toHaveBeenCalledWith(event.value);
+    });
+  });
+
+  describe("#onRemoveKeyword()", () => {
+    it("should emit an event", () => {
+      spyOn(component.removeKeyword, "emit");
+
+      const keyword = "test";
+      component.onRemoveKeyword(keyword);
+
+      expect(component.removeKeyword.emit).toHaveBeenCalledTimes(1);
+      expect(component.removeKeyword.emit).toHaveBeenCalledWith(keyword);
     });
   });
 

--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -1,6 +1,8 @@
 import { Component, Inject, Input, Output, EventEmitter } from "@angular/core";
 import { Attachment, Dataset } from "shared/sdk/models";
 import { APP_CONFIG, AppConfig } from "app-config.module";
+import { ENTER, COMMA, SPACE } from "@angular/cdk/keycodes";
+import { MatChipInputEvent } from "@angular/material";
 
 /**
  * Component to show details for a data set, using the
@@ -19,12 +21,35 @@ export class DatasetDetailComponent {
   @Input() attachments: Attachment[];
 
   @Output() clickKeyword = new EventEmitter<string>();
+  @Output() addKeyword = new EventEmitter<string>();
+  @Output() removeKeyword = new EventEmitter<string>();
   @Output() clickProposal = new EventEmitter<string>();
   @Output() clickSample = new EventEmitter<string>();
   @Output() saveMetadata = new EventEmitter<object>();
 
+  editEnabled: boolean;
+  readonly separatorKeyCodes: number[] = [ENTER, COMMA, SPACE];
+
   onClickKeyword(keyword: string): void {
     this.clickKeyword.emit(keyword);
+  }
+
+  onAddKeyword(event: MatChipInputEvent): void {
+    const input = event.input;
+    const value = event.value;
+
+    if ((value || "").trim()) {
+      const keyword = value.trim().toLowerCase();
+      this.addKeyword.emit(keyword);
+    }
+
+    if (input) {
+      input.value = "";
+    }
+  }
+
+  onRemoveKeyword(keyword: string): void {
+    this.removeKeyword.emit(keyword);
   }
 
   onClickProposal(proposalId: string): void {

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
@@ -37,6 +37,8 @@
         [datasetWithout]="datasetWithout$ | async"
         [attachments]="attachments$ | async"
         (clickKeyword)="onClickKeyword($event)"
+        (addKeyword)="onAddKeyword($event)"
+        (removeKeyword)="onRemoveKeyword($event)"
         (clickProposal)="onClickProposal($event)"
         (clickSample)="onClickSample($event)"
         (saveMetadata)="onSaveMetadata($event)"

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.spec.ts
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.spec.ts
@@ -174,14 +174,16 @@ describe("DetailsDashboardComponent", () => {
   describe("#onSlidePublic()", () => {
     it("should dispatch a updatePropertyAction", () => {
       dispatchSpy = spyOn(store, "dispatch");
+      const pid = "testPid";
       component.dataset = new RawDataset();
+      component.dataset.pid = pid;
       const event = new MatSlideToggleChange({} as MatSlideToggle, true);
       const property = { isPublished: true };
       component.onSlidePublic(event);
 
       expect(dispatchSpy).toHaveBeenCalledTimes(1);
       expect(dispatchSpy).toHaveBeenCalledWith(
-        updatePropertyAction({ dataset: component.dataset, property })
+        updatePropertyAction({ pid, property })
       );
     });
   });
@@ -198,6 +200,66 @@ describe("DetailsDashboardComponent", () => {
         addKeywordFilterAction({ keyword })
       );
       expect(router.navigateByUrl).toHaveBeenCalledWith("/datasets");
+    });
+  });
+
+  describe("#onAddKeyword()", () => {
+    it("should do nothing if keyword already exists", () => {
+      dispatchSpy = spyOn(store, "dispatch");
+
+      const keyword = "test";
+      component.dataset = new RawDataset();
+      component.dataset.keywords = [keyword];
+      component.onAddKeyword(keyword);
+
+      expect(dispatchSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it("should dispatch an updatePropertyAction if the keyword does not exist", () => {
+      dispatchSpy = spyOn(store, "dispatch");
+
+      const keyword = "test";
+      const pid = "testPid";
+      component.dataset = new RawDataset();
+      component.dataset.pid = pid;
+      component.dataset.keywords = [];
+      const property = { keywords: [keyword] };
+      component.onAddKeyword(keyword);
+
+      expect(dispatchSpy).toHaveBeenCalledTimes(1);
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        updatePropertyAction({ pid, property })
+      );
+    });
+  });
+
+  describe("#onRemoveKeyword()", () => {
+    it("should do nothing if the keyword does not exist", () => {
+      dispatchSpy = spyOn(store, "dispatch");
+
+      const keyword = "test";
+      component.dataset = new RawDataset();
+      component.dataset.keywords = [];
+      component.onRemoveKeyword(keyword);
+
+      expect(dispatchSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it("should dispatch an updatePropertyAction if the keyword does exist", () => {
+      dispatchSpy = spyOn(store, "dispatch");
+
+      const keyword = "test";
+      const pid = "testPid";
+      component.dataset = new RawDataset();
+      component.dataset.pid = pid;
+      component.dataset.keywords = [keyword];
+      const property = { keywords: [] };
+      component.onRemoveKeyword(keyword);
+
+      expect(dispatchSpy).toHaveBeenCalledTimes(1);
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        updatePropertyAction({ pid, property })
+      );
     });
   });
 
@@ -225,14 +287,16 @@ describe("DetailsDashboardComponent", () => {
     it("should dispatch a SaveDatasetAction", () => {
       dispatchSpy = spyOn(store, "dispatch");
 
+      const pid = "testPid";
       component.dataset = new RawDataset();
+      component.dataset.pid = pid;
       const metadata = {};
       const property = { scientificMetadata: metadata };
       component.onSaveMetadata(metadata);
 
       expect(dispatchSpy).toHaveBeenCalledTimes(1);
       expect(dispatchSpy).toHaveBeenCalledWith(
-        updatePropertyAction({ dataset: component.dataset, property })
+        updatePropertyAction({ pid, property })
       );
     });
   });

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
@@ -84,16 +84,35 @@ export class DatasetDetailsDashboardComponent
   }
 
   onSlidePublic(event: MatSlideToggleChange) {
+    const pid = this.dataset.pid;
     const property = { isPublished: event.checked };
-    this.store.dispatch(
-      updatePropertyAction({ dataset: this.dataset, property })
-    );
+    this.store.dispatch(updatePropertyAction({ pid, property }));
   }
 
   onClickKeyword(keyword: string) {
     this.store.dispatch(clearFacetsAction());
     this.store.dispatch(addKeywordFilterAction({ keyword }));
     this.router.navigateByUrl("/datasets");
+  }
+
+  onAddKeyword(keyword: string) {
+    if (this.dataset.keywords.indexOf(keyword) === -1) {
+      const pid = this.dataset.pid;
+      const keywords = [...this.dataset.keywords].concat(keyword);
+      const property = { keywords };
+      this.store.dispatch(updatePropertyAction({ pid, property }));
+    }
+  }
+
+  onRemoveKeyword(keyword: string) {
+    const index = this.dataset.keywords.indexOf(keyword);
+    if (index >= 0) {
+      const pid = this.dataset.pid;
+      const keywords = [...this.dataset.keywords];
+      keywords.splice(index, 1);
+      const property = { keywords };
+      this.store.dispatch(updatePropertyAction({ pid, property }));
+    }
   }
 
   onClickProposal(proposalId: string) {
@@ -107,10 +126,9 @@ export class DatasetDetailsDashboardComponent
   }
 
   onSaveMetadata(metadata: object) {
+    const pid = this.dataset.pid;
     const property = { scientificMetadata: metadata };
-    this.store.dispatch(
-      updatePropertyAction({ dataset: this.dataset, property })
-    );
+    this.store.dispatch(updatePropertyAction({ pid, property }));
   }
 
   resetDataset(dataset: Dataset) {

--- a/src/app/datasets/dataset-table/dataset-table.component.scss
+++ b/src/app/datasets/dataset-table/dataset-table.component.scss
@@ -31,7 +31,7 @@
   }
 
   mat-table {
-    overflow: scroll;
+    overflow-x: scroll;
 
     mat-header-row {
       min-width: 1290px;

--- a/src/app/state-management/actions/datasets.actions.spec.ts
+++ b/src/app/state-management/actions/datasets.actions.spec.ts
@@ -1,5 +1,5 @@
 import * as fromActions from "./datasets.actions";
-import { Dataset, Attachment, RawDataset } from "shared/sdk";
+import { Dataset, Attachment } from "shared/sdk";
 import { FacetCounts } from "state-management/state/datasets.store";
 import {
   ArchViewMode,

--- a/src/app/state-management/actions/datasets.actions.spec.ts
+++ b/src/app/state-management/actions/datasets.actions.spec.ts
@@ -140,12 +140,12 @@ describe("Dataset Actions", () => {
 
   describe("updatePropertyAction", () => {
     it("should create an action", () => {
-      const dataset = new RawDataset();
+      const pid = "testPid";
       const property = { isPublished: true };
-      const action = fromActions.updatePropertyAction({ dataset, property });
+      const action = fromActions.updatePropertyAction({ pid, property });
       expect({ ...action }).toEqual({
         type: "[Dataset] Update Property",
-        dataset,
+        pid,
         property
       });
     });

--- a/src/app/state-management/actions/datasets.actions.ts
+++ b/src/app/state-management/actions/datasets.actions.ts
@@ -55,7 +55,7 @@ export const clearBatchAction = createAction("[Dataset] Clear Batch");
 
 export const updatePropertyAction = createAction(
   "[Dataset] Update Property",
-  props<{ dataset: RawDataset | DerivedDataset; property: object }>()
+  props<{ pid: string; property: object }>()
 );
 export const updatePropertyCompleteAction = createAction(
   "[Dataset] Update Property Complete"

--- a/src/app/state-management/actions/datasets.actions.ts
+++ b/src/app/state-management/actions/datasets.actions.ts
@@ -1,5 +1,5 @@
 import { createAction, props } from "@ngrx/store";
-import { Dataset, Attachment, RawDataset, DerivedDataset } from "shared/sdk";
+import { Dataset, Attachment } from "shared/sdk";
 import { FacetCounts } from "state-management/state/datasets.store";
 import {
   ArchViewMode,

--- a/src/app/state-management/effects/datasets.effects.spec.ts
+++ b/src/app/state-management/effects/datasets.effects.spec.ts
@@ -2,13 +2,7 @@ import { TestBed } from "@angular/core/testing";
 import { provideMockActions } from "@ngrx/effects/testing";
 import { provideMockStore } from "@ngrx/store/testing";
 import { cold, hot } from "jasmine-marbles";
-import {
-  DatasetInterface,
-  Dataset,
-  DatasetApi,
-  Attachment,
-  RawDataset
-} from "shared/sdk";
+import { DatasetInterface, Dataset, DatasetApi, Attachment } from "shared/sdk";
 import * as fromActions from "../actions/datasets.actions";
 import { Observable } from "rxjs";
 import { DatasetEffects } from "./datasets.effects";

--- a/src/app/state-management/effects/datasets.effects.spec.ts
+++ b/src/app/state-management/effects/datasets.effects.spec.ts
@@ -172,15 +172,15 @@ describe("DatasetEffects", () => {
   });
 
   describe("updateProperty$", () => {
-    const rawDataset = new RawDataset();
+    const pid = "testPid";
     const property = { isPublished: true };
     it("should result in a updatePropertyCompleteAction and a fetchDatasetAction", () => {
       const action = fromActions.updatePropertyAction({
-        dataset: rawDataset,
+        pid,
         property
       });
       const outcome1 = fromActions.updatePropertyCompleteAction();
-      const outcome2 = fromActions.fetchDatasetAction({ pid: rawDataset.pid });
+      const outcome2 = fromActions.fetchDatasetAction({ pid });
 
       actions = hot("-a", { a: action });
       const response = cold("-a|", { a: dataset });
@@ -192,7 +192,7 @@ describe("DatasetEffects", () => {
 
     it("should result in a updatePropertyFailedAction", () => {
       const action = fromActions.updatePropertyAction({
-        dataset: rawDataset,
+        pid,
         property
       });
       const outcome = fromActions.updatePropertyFailedAction();
@@ -379,10 +379,10 @@ describe("DatasetEffects", () => {
 
     describe("ofType updatePropertyAction", () => {
       it("should dispatch a loadingAction", () => {
-        const rawDataset = new RawDataset();
+        const pid = "testPid";
         const property = { isPublished: true };
         const action = fromActions.updatePropertyAction({
-          dataset: rawDataset,
+          pid,
           property
         });
         const outcome = loadingAction();

--- a/src/app/state-management/effects/datasets.effects.ts
+++ b/src/app/state-management/effects/datasets.effects.ts
@@ -103,13 +103,13 @@ export class DatasetEffects {
   updateProperty$ = createEffect(() =>
     this.actions$.pipe(
       ofType(fromActions.updatePropertyAction),
-      switchMap(({ dataset, property }) =>
+      switchMap(({ pid, property }) =>
         this.datasetApi
-          .updateAttributes(encodeURIComponent(dataset.pid), property)
+          .updateAttributes(encodeURIComponent(pid), property)
           .pipe(
             switchMap(() => [
               fromActions.updatePropertyCompleteAction(),
-              fromActions.fetchDatasetAction({ pid: dataset.pid })
+              fromActions.fetchDatasetAction({ pid })
             ]),
             catchError(() => of(fromActions.updatePropertyFailedAction()))
           )


### PR DESCRIPTION
## Description

Added functionality for adding and removing dataset keywords

## Motivation

Requested

## Changes:

* Added 'Add Keyword' chip to dataset keywords
* Added 'Remove chip' button to existing keyword chips
* Changed props of updateAttributeAction to accept a pid instead of an entire dataset

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

