### PR TITLE
dataset attachments not working correctly for multiple reasons

### DIFF
--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
@@ -85,7 +85,7 @@
 
       <div class="file-uploader">
         <app-file-uploader
-          [attachments]="attachments$ | async"
+          [attachments]="attachments"
           (filePicked)="onFileUploaderFilePicked($event)"
           (readEnd)="onFileUploaderReadEnd($event)"
           (submitCaption)="updateCaption($event)"

--- a/src/app/state-management/effects/datasets.effects.ts
+++ b/src/app/state-management/effects/datasets.effects.ts
@@ -172,7 +172,7 @@ export class DatasetEffects {
           )
           .pipe(
             map(res =>
-              fromActions.removeAttachmentCompleteAction({ attachmentId: res })
+              fromActions.removeAttachmentCompleteAction({ attachmentId })
             ),
             catchError(() => of(fromActions.removeAttachmentFailedAction()))
           )

--- a/src/app/state-management/effects/datasets.effects.ts
+++ b/src/app/state-management/effects/datasets.effects.ts
@@ -127,7 +127,7 @@ export class DatasetEffects {
         delete attachment.proposalId;
         delete attachment.sampleId;
         return this.datasetApi
-          .createAttachments(encodeURI(attachment.datasetId), attachment)
+          .createAttachments(encodeURIComponent(attachment.datasetId), attachment)
           .pipe(
             map(res =>
               fromActions.addAttachmentCompleteAction({ attachment: res })
@@ -168,7 +168,7 @@ export class DatasetEffects {
         this.datasetApi
           .destroyByIdAttachments(
             encodeURIComponent(datasetId),
-            encodeURIComponent(attachmentId)
+            attachmentId
           )
           .pipe(
             map(res =>

--- a/src/app/state-management/effects/datasets.effects.ts
+++ b/src/app/state-management/effects/datasets.effects.ts
@@ -127,7 +127,10 @@ export class DatasetEffects {
         delete attachment.proposalId;
         delete attachment.sampleId;
         return this.datasetApi
-          .createAttachments(encodeURIComponent(attachment.datasetId), attachment)
+          .createAttachments(
+            encodeURIComponent(attachment.datasetId),
+            attachment
+          )
           .pipe(
             map(res =>
               fromActions.addAttachmentCompleteAction({ attachment: res })
@@ -166,12 +169,9 @@ export class DatasetEffects {
       ofType(fromActions.removeAttachmentAction),
       switchMap(({ datasetId, attachmentId }) =>
         this.datasetApi
-          .destroyByIdAttachments(
-            encodeURIComponent(datasetId),
-            attachmentId
-          )
+          .destroyByIdAttachments(encodeURIComponent(datasetId), attachmentId)
           .pipe(
-            map(res =>
+            map(() =>
               fromActions.removeAttachmentCompleteAction({ attachmentId })
             ),
             catchError(() => of(fromActions.removeAttachmentFailedAction()))

--- a/src/app/state-management/reducers/datasets.reducer.ts
+++ b/src/app/state-management/reducers/datasets.reducer.ts
@@ -48,7 +48,9 @@ const reducer = createReducer(
   on(fromActions.clearBatchAction, state => ({ ...state, batch: [] })),
 
   on(fromActions.addAttachmentCompleteAction, (state, { attachment }) => {
-    const attachments = state.currentSet.attachments;
+    const attachments = state.currentSet.attachments.filter(
+      existingAttachment => existingAttachment.id !== attachment.id
+    );
     attachments.push(attachment);
     const currentSet = { ...state.currentSet, attachments };
     return { ...state, currentSet };


### PR DESCRIPTION
## Description

firstly, PIDs are not correctly encoded before making api calls.
secondly, the complete reducer is called twice, adding the entity to state twice
thirdly, remove does not remove the item from state or change detection is not functioning correctly 

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

