### PR TITLE
Hotfix/publish navigation

### DIFF
--- a/src/app/datasets/publish/publish.component.ts
+++ b/src/app/datasets/publish/publish.component.ts
@@ -8,7 +8,8 @@ import { getDatasetsInBatch } from "state-management/selectors/datasets.selector
 import { prefillBatchAction } from "state-management/actions/datasets.actions";
 import {
   publishDatasetAction,
-  publishDatasetCompleteAction
+  publishDatasetCompleteAction,
+  fetchPublishedDataCompleteAction
 } from "state-management/actions/published-data.actions";
 import { APP_CONFIG } from "app-config.module";
 
@@ -123,7 +124,7 @@ export class PublishComponent implements OnInit, OnDestroy {
       });
 
     this.actionSubjectSubscription = this.actionsSubj.subscribe(data => {
-      if (data.type === publishDatasetCompleteAction.type) {
+      if (data.type === fetchPublishedDataCompleteAction.type) {
         this.store
           .pipe(select(getCurrentPublishedData))
           .subscribe(publishedData => {

--- a/src/app/datasets/publish/publish.component.ts
+++ b/src/app/datasets/publish/publish.component.ts
@@ -8,7 +8,6 @@ import { getDatasetsInBatch } from "state-management/selectors/datasets.selector
 import { prefillBatchAction } from "state-management/actions/datasets.actions";
 import {
   publishDatasetAction,
-  publishDatasetCompleteAction,
   fetchPublishedDataCompleteAction
 } from "state-management/actions/published-data.actions";
 import { APP_CONFIG } from "app-config.module";


### PR DESCRIPTION
## Description

Publish component should navigate to the published data details page after the new published data has been fetched.

## Motivation

Bugfix

## Changes:

* Changed actionsSubjectSubscription to wait for fetchPublishedDataCompleteAction instead of publishDatasetCompleteAction

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

