### PR TITLE
Added functionality for adding attachments to samples

### DIFF
--- a/src/app/samples/sample-detail/sample-detail.component.html
+++ b/src/app/samples/sample-detail/sample-detail.component.html
@@ -1,103 +1,136 @@
-<div *ngIf="sample">
-  <mat-tab-group>
-    <mat-tab>
-      <ng-template mat-tab-label>
-        <mat-icon> details </mat-icon> Details
-      </ng-template>
+<mat-tab-group *ngIf="sample">
+  <mat-tab>
+    <ng-template mat-tab-label>
+      <mat-icon> details </mat-icon> Details
+    </ng-template>
 
-      <mat-card>
-        <mat-card-header class="about-header">
-          Sample Details
-        </mat-card-header>
-        <div class="details">
-          <table>
-            <tr *ngIf="sample.description as value">
-              <th><mat-icon> description </mat-icon>Description</th>
-              <td>{{ value }}</td>
-            </tr>
-            <tr *ngIf="sample.createdAt as value">
-              <th><mat-icon> event </mat-icon>Creation Time</th>
-              <td>{{ value | date: "yyyy-MM-dd HH:mm" }}</td>
-            </tr>
-            <tr *ngIf="sample.owner as value">
-              <th><mat-icon> person </mat-icon>Sample Owner</th>
-              <td>{{ value }}</td>
-            </tr>
-            <tr *ngIf="sample.ownerGroup as value">
-              <th><mat-icon> group </mat-icon>Owner Group</th>
-              <td>{{ value }}</td>
-            </tr>
-            <tr *ngIf="sample.sampleId as value">
-              <th><mat-icon> fingerprint </mat-icon>Sample ID</th>
-              <td>{{ value }}</td>
-            </tr>
-          </table>
-        </div>
-      </mat-card>
+    <div fxLayout="row" fxLayout.xs="column">
+      <div fxFlex="80%">
+        <mat-card>
+          <mat-card-header class="about-header">
+            Sample Details
+          </mat-card-header>
+          <div class="details">
+            <table>
+              <tr *ngIf="sample.description as value">
+                <th><mat-icon> description </mat-icon>Description</th>
+                <td>{{ value }}</td>
+              </tr>
+              <tr *ngIf="sample.createdAt as value">
+                <th><mat-icon> event </mat-icon>Creation Time</th>
+                <td>{{ value | date: "yyyy-MM-dd HH:mm" }}</td>
+              </tr>
+              <tr *ngIf="sample.owner as value">
+                <th><mat-icon> person </mat-icon>Sample Owner</th>
+                <td>{{ value }}</td>
+              </tr>
+              <tr *ngIf="sample.ownerGroup as value">
+                <th><mat-icon> group </mat-icon>Owner Group</th>
+                <td>{{ value }}</td>
+              </tr>
+              <tr *ngIf="sample.sampleId as value">
+                <th><mat-icon> fingerprint </mat-icon>Sample ID</th>
+                <td>{{ value }}</td>
+              </tr>
+            </table>
+          </div>
+        </mat-card>
 
-      <mat-card *ngIf="sample.sampleCharacteristics as value">
-        <mat-card-header class="characteristics-header">
-          Characteristics
-        </mat-card-header>
+        <mat-card *ngIf="sample.sampleCharacteristics as value">
+          <mat-card-header class="characteristics-header">
+            Characteristics
+          </mat-card-header>
 
-        <ng-template
-          [ngIf]="appConfig.tableSciDataEnabled"
-          [ngIfElse]="jsonView"
-        >
-          <mat-tab-group>
-            <mat-tab>
-              <ng-template mat-tab-label>
-                <mat-icon> list </mat-icon> View
-              </ng-template>
+          <ng-template
+            [ngIf]="appConfig.tableSciDataEnabled"
+            [ngIfElse]="jsonView"
+          >
+            <mat-tab-group>
+              <mat-tab>
+                <ng-template mat-tab-label>
+                  <mat-icon> list </mat-icon> View
+                </ng-template>
 
-              <metadata-view [metadata]="value"></metadata-view>
-            </mat-tab>
-            <mat-tab>
-              <ng-template mat-tab-label>
-                <mat-icon> edit </mat-icon> Edit
-              </ng-template>
+                <metadata-view [metadata]="value"></metadata-view>
+              </mat-tab>
+              <mat-tab>
+                <ng-template mat-tab-label>
+                  <mat-icon> edit </mat-icon> Edit
+                </ng-template>
 
-              <metadata-edit
-                [metadata]="value"
-                (save)="onSaveCharacteristics($event)"
-              ></metadata-edit>
-            </mat-tab>
-          </mat-tab-group>
-        </ng-template>
+                <metadata-edit
+                  [metadata]="value"
+                  (save)="onSaveCharacteristics($event)"
+                ></metadata-edit>
+              </mat-tab>
+            </mat-tab-group>
+          </ng-template>
 
-        <ng-template #jsonView>
-          <ngx-json-viewer [json]="value" [expanded]="false"></ngx-json-viewer>
-        </ng-template>
-      </mat-card>
+          <ng-template #jsonView>
+            <ngx-json-viewer
+              [json]="value"
+              [expanded]="false"
+            ></ngx-json-viewer>
+          </ng-template>
+        </mat-card>
 
-      <mat-card>
-        <button mat-stroked-button (click)="show = !show">
-          {{ show ? "Hide MetaData" : "Show Metadata" }}
-        </button>
-        <br />
-        <div *ngIf="show">
-          <ngx-json-viewer [json]="sample" [expanded]="false"></ngx-json-viewer>
-        </div>
-      </mat-card>
-    </mat-tab>
-
-    <mat-tab>
-      <ng-template mat-tab-label>
-        <mat-icon> folder </mat-icon> Datasets
-      </ng-template>
-
-      <div class="datasets-table">
-        <app-table
-          [data]="tableData"
-          [columns]="tableColumns"
-          [paginate]="tablePaginate"
-          [currentPage]="datasetsPage$ | async"
-          [dataCount]="datasetsCount$ | async"
-          [dataPerPage]="datasetsPerPage$ | async"
-          (pageChange)="onPageChange($event)"
-          (rowClick)="onRowClick($event)"
-        ></app-table>
+        <mat-card>
+          <button mat-stroked-button (click)="show = !show">
+            {{ show ? "Hide MetaData" : "Show Metadata" }}
+          </button>
+          <br />
+          <div *ngIf="show">
+            <ngx-json-viewer
+              [json]="sample"
+              [expanded]="false"
+            ></ngx-json-viewer>
+          </div>
+        </mat-card>
       </div>
-    </mat-tab>
-  </mat-tab-group>
-</div>
+
+      <div fxFlex="30%" *ngIf="attachments$ | async as attachments">
+        <ng-container *ngFor="let attachment of attachments">
+          <mat-card>
+            <img mat-card-image src="{{ attachment.thumbnail }}" />
+            <p>{{ attachment.caption }}</p>
+          </mat-card>
+        </ng-container>
+      </div>
+    </div>
+  </mat-tab>
+
+  <mat-tab *ngIf="attachments$ | async as attachments">
+    <ng-template mat-tab-label>
+      <mat-icon> insert_photo </mat-icon> Attachments
+    </ng-template>
+
+    <div class="file-uploader">
+      <app-file-uploader
+        [attachments]="attachments"
+        (filePicked)="onFilePicked($event)"
+        (readEnd)="onReadEnd($event)"
+        (submitCaption)="updateCaption($event)"
+        (deleteAttachment)="deleteAttachment($event)"
+      ></app-file-uploader>
+    </div>
+  </mat-tab>
+
+  <mat-tab>
+    <ng-template mat-tab-label>
+      <mat-icon> folder </mat-icon> Datasets
+    </ng-template>
+
+    <div class="datasets-table">
+      <app-table
+        [data]="tableData"
+        [columns]="tableColumns"
+        [paginate]="tablePaginate"
+        [currentPage]="datasetsPage$ | async"
+        [dataCount]="datasetsCount$ | async"
+        [dataPerPage]="datasetsPerPage$ | async"
+        (pageChange)="onPageChange($event)"
+        (rowClick)="onRowClick($event)"
+      ></app-table>
+    </div>
+  </mat-tab>
+</mat-tab-group>

--- a/src/app/samples/sample-detail/sample-detail.component.scss
+++ b/src/app/samples/sample-detail/sample-detail.component.scss
@@ -33,6 +33,10 @@ mat-card {
   }
 }
 
+.file-uploader {
+  margin: 1em;
+}
+
 .datasets-table {
   margin: 1em;
 }

--- a/src/app/samples/sample-detail/sample-detail.component.ts
+++ b/src/app/samples/sample-detail/sample-detail.component.ts
@@ -1,20 +1,24 @@
 import { ActivatedRoute, Router } from "@angular/router";
 import { Component, OnDestroy, OnInit, Inject } from "@angular/core";
 import { Subscription } from "rxjs";
-import { Sample, Dataset } from "../../shared/sdk/models";
+import { Sample, Dataset, Attachment } from "../../shared/sdk/models";
 import {
   getCurrentSample,
   getDatasets,
   getDatasetsPerPage,
   getDatasetsPage,
-  getDatasetsCount
+  getDatasetsCount,
+  getCurrentAttachments
 } from "../../state-management/selectors/samples.selectors";
 import { select, Store } from "@ngrx/store";
 import {
   fetchSampleAction,
   fetchSampleDatasetsAction,
   changeDatasetsPageAction,
-  saveCharacteristicsAction
+  saveCharacteristicsAction,
+  addAttachmentAction,
+  updateAttachmentCaptionAction,
+  removeAttachmentAction
 } from "../../state-management/actions/samples.actions";
 import { DatePipe, SlicePipe } from "@angular/common";
 import { FileSizePipe } from "shared/pipes/filesize.pipe";
@@ -23,6 +27,8 @@ import {
   PageChangeEvent
 } from "shared/modules/table/table.component";
 import { APP_CONFIG, AppConfig } from "app-config.module";
+import { ReadFile } from "ngx-file-helpers";
+import { SubmitCaptionEvent } from "shared/modules/file-uploader/file-uploader.component";
 
 @Component({
   selector: "app-sample-detail",
@@ -30,14 +36,16 @@ import { APP_CONFIG, AppConfig } from "app-config.module";
   styleUrls: ["./sample-detail.component.scss"]
 })
 export class SampleDetailComponent implements OnInit, OnDestroy {
+  attachments$ = this.store.pipe(select(getCurrentAttachments));
   datasetsPerPage$ = this.store.pipe(select(getDatasetsPerPage));
   datasetsPage$ = this.store.pipe(select(getDatasetsPage));
   datasetsCount$ = this.store.pipe(select(getDatasetsCount));
 
   sample: Sample;
-  sampleSubscription: Subscription;
-  datasetsSubscription: Subscription;
-  routeSubscription: Subscription;
+  pickedFile: ReadFile;
+  attachment: Attachment;
+
+  subscriptions: Subscription[] = [];
 
   tableData: any[];
   tablePaginate = true;
@@ -79,6 +87,47 @@ export class SampleDetailComponent implements OnInit, OnDestroy {
     );
   }
 
+  onFilePicked(file: ReadFile) {
+    this.pickedFile = file;
+  }
+
+  onReadEnd(filecount: number) {
+    if (filecount > 0) {
+      this.attachment = {
+        thumbnail: this.pickedFile.content,
+        caption: this.pickedFile.name,
+        creationTime: new Date(),
+        id: null,
+        sample: this.sample,
+        sampleId: this.sample.sampleId,
+        dataset: null,
+        datasetId: null,
+        rawDatasetId: null,
+        derivedDatasetId: null,
+        proposal: null,
+        proposalId: null
+      };
+      this.store.dispatch(addAttachmentAction({ attachment: this.attachment }));
+    }
+  }
+
+  updateCaption(event: SubmitCaptionEvent) {
+    const { attachmentId, caption } = event;
+    this.store.dispatch(
+      updateAttachmentCaptionAction({
+        sampleId: this.sample.sampleId,
+        attachmentId,
+        caption
+      })
+    );
+  }
+
+  deleteAttachment(attachmentId: string) {
+    this.store.dispatch(
+      removeAttachmentAction({ sampleId: this.sample.sampleId, attachmentId })
+    );
+  }
+
   onPageChange(event: PageChangeEvent) {
     this.store.dispatch(
       changeDatasetsPageAction({ page: event.pageIndex, limit: event.pageSize })
@@ -104,27 +153,27 @@ export class SampleDetailComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.sampleSubscription = this.store
-      .pipe(select(getCurrentSample))
-      .subscribe(sample => {
+    this.subscriptions.push(
+      this.store.pipe(select(getCurrentSample)).subscribe(sample => {
         this.sample = sample;
-      });
+      })
+    );
 
-    this.datasetsSubscription = this.store
-      .pipe(select(getDatasets))
-      .subscribe(datasets => {
+    this.subscriptions.push(
+      this.store.pipe(select(getDatasets)).subscribe(datasets => {
         this.tableData = this.formatTableData(datasets);
-      });
+      })
+    );
 
-    this.routeSubscription = this.route.params.subscribe(params => {
-      this.store.dispatch(fetchSampleAction({ sampleId: params.id }));
-      this.store.dispatch(fetchSampleDatasetsAction({ sampleId: params.id }));
-    });
+    this.subscriptions.push(
+      this.route.params.subscribe(params => {
+        this.store.dispatch(fetchSampleAction({ sampleId: params.id }));
+        this.store.dispatch(fetchSampleDatasetsAction({ sampleId: params.id }));
+      })
+    );
   }
 
   ngOnDestroy() {
-    this.sampleSubscription.unsubscribe();
-    this.datasetsSubscription.unsubscribe();
-    this.routeSubscription.unsubscribe();
+    this.subscriptions.forEach(subscription => subscription.unsubscribe());
   }
 }

--- a/src/app/state-management/effects/samples.effects.spec.ts
+++ b/src/app/state-management/effects/samples.effects.spec.ts
@@ -49,7 +49,7 @@ describe("SampleEffects", () => {
           provide: SampleApi,
           useValue: jasmine.createSpyObj("sampleApi", [
             "fullquery",
-            "findById",
+            "findOne",
             "patchAttributes",
             "create",
             "createAttachments",
@@ -229,7 +229,7 @@ describe("SampleEffects", () => {
 
       actions = hot("-a", { a: action });
       const response = cold("-a|", { a: sample });
-      sampleApi.findById.and.returnValue(response);
+      sampleApi.findOne.and.returnValue(response);
 
       const expected = cold("--b", { b: outcome });
       expect(effects.fetchSample$).toBeObservable(expected);
@@ -241,7 +241,7 @@ describe("SampleEffects", () => {
 
       actions = hot("-a", { a: action });
       const response = cold("-#", {});
-      sampleApi.findById.and.returnValue(response);
+      sampleApi.findOne.and.returnValue(response);
 
       const expected = cold("--b", { b: outcome });
       expect(effects.fetchSample$).toBeObservable(expected);

--- a/src/app/state-management/effects/samples.effects.ts
+++ b/src/app/state-management/effects/samples.effects.ts
@@ -70,14 +70,20 @@ export class SampleEffects {
   fetchSample$ = createEffect(() =>
     this.actions$.pipe(
       ofType(fromActions.fetchSampleAction),
-      switchMap(({ sampleId }) =>
-        this.sampleApi.findById(sampleId).pipe(
+      switchMap(({ sampleId }) => {
+        const sampleFilter = {
+          where: {
+            sampleId
+          },
+          include: [{ relation: "attachments" }]
+        };
+        return this.sampleApi.findOne(sampleFilter).pipe(
           map((sample: Sample) =>
             fromActions.fetchSampleCompleteAction({ sample })
           ),
           catchError(() => of(fromActions.fetchSampleFailedAction()))
-        )
-      )
+        );
+      })
     )
   );
 
@@ -203,8 +209,8 @@ export class SampleEffects {
             encodeURIComponent(attachmentId)
           )
           .pipe(
-            map(res =>
-              fromActions.removeAttachmentCompleteAction({ attachmentId: res })
+            map(() =>
+              fromActions.removeAttachmentCompleteAction({ attachmentId })
             ),
             catchError(() => of(fromActions.removeAttachmentFailedAction()))
           )

--- a/src/app/state-management/reducers/samples.reducer.ts
+++ b/src/app/state-management/reducers/samples.reducer.ts
@@ -44,7 +44,9 @@ const reducer = createReducer(
   })),
 
   on(fromActions.addAttachmentCompleteAction, (state, { attachment }) => {
-    const attachments = state.currentSample.attachments;
+    const attachments = state.currentSample.attachments.filter(
+      existingAttachment => existingAttachment.id !== attachment.id
+    );
     attachments.push(attachment);
     const currentSample = { ...state.currentSample, attachments };
     return { ...state, currentSample };


### PR DESCRIPTION
## Description

Added functionality for adding attachments to samples

## Motivation

Requested

## Changes:

* Added shared file uploader to new tab in sample details
* Added attachment viewer to sample details tab
* Updated fetchSample$ effect to include attachments relation
* Added filter to attachments for addAttachmentCompleteAction in samples reducer

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [x] Requires update of catamel API?

