### PR TITLE
Added router state to all dashboard components

### DIFF
--- a/src/app/jobs/jobs-dashboard/jobs-dashboard.component.spec.ts
+++ b/src/app/jobs/jobs-dashboard/jobs-dashboard.component.spec.ts
@@ -14,7 +14,6 @@ import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { MatButtonToggleModule } from "@angular/material";
 import { SharedCatanieModule } from "shared/shared.module";
 import { DatePipe } from "@angular/common";
-import { rootReducer } from "state-management/reducers/root.reducer";
 import { JobViewMode } from "state-management/models";
 import {
   setJobViewModeAction,
@@ -39,7 +38,7 @@ describe("JobsDashboardComponent", () => {
       imports: [
         MatButtonToggleModule,
         SharedCatanieModule,
-        StoreModule.forRoot({ rootReducer })
+        StoreModule.forRoot({})
       ],
       providers: [DatePipe]
     });

--- a/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.ts
+++ b/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.ts
@@ -18,9 +18,10 @@ import {
   fetchFilteredEntriesAction,
   setFilterAction
 } from "state-management/actions/logbooks.actions";
-import { ActivatedRoute } from "@angular/router";
+import { ActivatedRoute, Router } from "@angular/router";
 import { APP_CONFIG, AppConfig } from "app-config.module";
 import { LogbookFilters } from "state-management/models";
+import * as rison from "rison";
 
 @Component({
   selector: "app-logbooks-dashboard",
@@ -34,6 +35,14 @@ export class LogbooksDashboardComponent
 
   subscriptions: Subscription[] = [];
 
+  applyRouterState() {
+    if (this.logbook && this.filters) {
+      this.router.navigate(["/logbooks", this.logbook.name], {
+        queryParams: { args: rison.encode(this.filters) }
+      });
+    }
+  }
+
   onTextSearchChange(query: string) {
     this.filters.textSearch = query;
     this.store.dispatch(setFilterAction({ filters: this.filters }));
@@ -43,6 +52,7 @@ export class LogbooksDashboardComponent
         filters: this.filters
       })
     );
+    this.applyRouterState();
   }
 
   onFilterSelect(filters: LogbookFilters) {
@@ -54,6 +64,7 @@ export class LogbooksDashboardComponent
         filters: this.filters
       })
     );
+    this.applyRouterState();
   }
 
   reverseTimeline(): void {
@@ -63,6 +74,7 @@ export class LogbooksDashboardComponent
   constructor(
     private cdRef: ChangeDetectorRef,
     private route: ActivatedRoute,
+    private router: Router,
     private store: Store<Logbook>,
     @Inject(APP_CONFIG) public appConfig: AppConfig
   ) {}
@@ -75,8 +87,8 @@ export class LogbooksDashboardComponent
     );
 
     this.subscriptions.push(
-      this.store.pipe(select(getFilters)).subscribe(filter => {
-        this.filters = filter;
+      this.store.pipe(select(getFilters)).subscribe(filters => {
+        this.filters = filters;
       })
     );
 
@@ -88,6 +100,8 @@ export class LogbooksDashboardComponent
         }
       })
     );
+
+    this.applyRouterState();
   }
 
   ngAfterViewChecked() {

--- a/src/app/logbooks/logbooks-table/logbooks-table.component.spec.ts
+++ b/src/app/logbooks/logbooks-table/logbooks-table.component.spec.ts
@@ -12,7 +12,7 @@ describe("LogbooksTableComponent", () => {
   let component: LogbooksTableComponent;
   let fixture: ComponentFixture<LogbooksTableComponent>;
 
-  let router = {
+  const router = {
     navigateByUrl: jasmine.createSpy("navigateByUrl")
   };
 

--- a/src/app/logbooks/logbooks-table/logbooks-table.component.ts
+++ b/src/app/logbooks/logbooks-table/logbooks-table.component.ts
@@ -18,6 +18,10 @@ export class LogbooksTableComponent implements OnInit, OnDestroy {
 
   columnsToDisplay: string[] = ["name", "latestEntry", "sender", "entry"];
 
+  onClick(logbook: Logbook): void {
+    this.router.navigateByUrl("/logbooks/" + logbook.name);
+  }
+
   constructor(private router: Router, private store: Store<Logbook[]>) {}
 
   ngOnInit() {
@@ -35,9 +39,5 @@ export class LogbooksTableComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.logbooksSubscription.unsubscribe();
-  }
-
-  onClick(logbook: Logbook): void {
-    this.router.navigateByUrl("/logbooks/" + logbook.name);
   }
 }

--- a/src/app/policies/policies-dashboard/policies-dashboard.component.html
+++ b/src/app/policies/policies-dashboard/policies-dashboard.component.html
@@ -1,7 +1,9 @@
-<mat-tab-group>
+<mat-tab-group (selectedTabChange)="onTabChange($event)">
   <mat-tab>
     <ng-template mat-tab-label>
-      Readable
+      <ng-container>
+        Readable
+      </ng-container>
     </ng-template>
 
     <div fxLayout="row">

--- a/src/app/policies/policies-dashboard/policies-dashboard.component.spec.ts
+++ b/src/app/policies/policies-dashboard/policies-dashboard.component.spec.ts
@@ -9,7 +9,7 @@ import { PoliciesDashboardComponent } from "./policies-dashboard.component";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { SharedCatanieModule } from "shared/shared.module";
 import { DatasetApi, Policy } from "shared/sdk";
-import { MockDatasetApi, MockStore, MockRouter } from "shared/MockStubs";
+import { MockDatasetApi, MockStore } from "shared/MockStubs";
 import { StoreModule, Store } from "@ngrx/store";
 import {
   PageChangeEvent,

--- a/src/app/policies/policies.module.ts
+++ b/src/app/policies/policies.module.ts
@@ -1,5 +1,5 @@
-import { PolicyEffects } from './../state-management/effects/policies.effects';
-import { EffectsModule } from '@ngrx/effects';
+import { PolicyEffects } from "./../state-management/effects/policies.effects";
+import { EffectsModule } from "@ngrx/effects";
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";

--- a/src/app/proposals/proposal-dashboard/proposal-dashboard.component.spec.ts
+++ b/src/app/proposals/proposal-dashboard/proposal-dashboard.component.spec.ts
@@ -9,7 +9,6 @@ import {
   TestBed,
   inject
 } from "@angular/core/testing";
-import { rootReducer } from "state-management/reducers/root.reducer";
 import { SharedCatanieModule } from "shared/shared.module";
 import { DatePipe } from "@angular/common";
 import { Proposal } from "shared/sdk";
@@ -42,7 +41,7 @@ describe("ProposalDashboardComponent", () => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
       declarations: [ProposalDashboardComponent],
-      imports: [SharedCatanieModule, StoreModule.forRoot({ rootReducer })],
+      imports: [SharedCatanieModule, StoreModule.forRoot({})],
       providers: [DatePipe]
     });
     TestBed.overrideComponent(ProposalDashboardComponent, {

--- a/src/app/proposals/proposal-dashboard/proposal-dashboard.component.ts
+++ b/src/app/proposals/proposal-dashboard/proposal-dashboard.component.ts
@@ -11,7 +11,8 @@ import {
   getProposalsPerPage,
   getProposals,
   getDateRangeFilter,
-  getHasAppliedFilters
+  getHasAppliedFilters,
+  getFilters
 } from "state-management/selectors/proposals.selectors";
 import {
   TableColumn,
@@ -27,6 +28,7 @@ import {
   clearFacetsAction
 } from "state-management/actions/proposals.actions";
 import { DateRange } from "datasets/datasets-filter/datasets-filter.component";
+import * as rison from "rison";
 
 @Component({
   selector: "proposal-dashboard",
@@ -34,14 +36,14 @@ import { DateRange } from "datasets/datasets-filter/datasets-filter.component";
   styleUrls: ["./proposal-dashboard.component.scss"]
 })
 export class ProposalDashboardComponent implements OnInit, OnDestroy {
-  private proposalsSubscription: Subscription;
-  clearSearchBar: boolean;
-
   hasAppliedFilters$ = this.store.pipe(select(getHasAppliedFilters));
   dateRangeFilter$ = this.store.pipe(select(getDateRangeFilter));
   currentPage$ = this.store.pipe(select(getPage));
   proposalsCount$ = this.store.pipe(select(getProposalsCount));
   proposalsPerPage$ = this.store.pipe(select(getProposalsPerPage));
+
+  clearSearchBar: boolean;
+  subscriptions: Subscription[] = [];
 
   tableData: any[];
   tableColumns: TableColumn[] = [
@@ -170,14 +172,22 @@ export class ProposalDashboardComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.store.dispatch(fetchProposalsAction());
 
-    this.proposalsSubscription = this.store
-      .pipe(select(getProposals))
-      .subscribe(proposals => {
+    this.subscriptions.push(
+      this.store.pipe(select(getProposals)).subscribe(proposals => {
         this.tableData = this.formatTableData(proposals);
-      });
+      })
+    );
+
+    this.subscriptions.push(
+      this.store.pipe(select(getFilters)).subscribe(filters => {
+        this.router.navigate(["/proposals"], {
+          queryParams: { args: rison.encode(filters) }
+        });
+      })
+    );
   }
 
   ngOnDestroy() {
-    this.proposalsSubscription.unsubscribe();
+    this.subscriptions.forEach(subscription => subscription.unsubscribe());
   }
 }

--- a/src/app/publisheddata/publisheddata-dashboard/publisheddata-dashboard.component.spec.ts
+++ b/src/app/publisheddata/publisheddata-dashboard/publisheddata-dashboard.component.spec.ts
@@ -9,7 +9,6 @@ import { PublisheddataDashboardComponent } from "./publisheddata-dashboard.compo
 import { MockStore } from "shared/MockStubs";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { StoreModule, Store } from "@ngrx/store";
-import { rootReducer } from "state-management/reducers/root.reducer";
 import { Router } from "@angular/router";
 import { PageChangeEvent } from "shared/modules/table/table.component";
 import { changePageAction } from "state-management/actions/published-data.actions";
@@ -29,7 +28,7 @@ describe("PublisheddataDashboardComponent", () => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
       declarations: [PublisheddataDashboardComponent],
-      imports: [StoreModule.forRoot({ rootReducer })]
+      imports: [StoreModule.forRoot({})]
     });
     TestBed.overrideComponent(PublisheddataDashboardComponent, {
       set: {

--- a/src/app/publisheddata/publisheddata-dashboard/publisheddata-dashboard.component.ts
+++ b/src/app/publisheddata/publisheddata-dashboard/publisheddata-dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, OnInit, OnDestroy } from "@angular/core";
 import { Store, select } from "@ngrx/store";
 import { PublishedData } from "shared/sdk";
 import { Router } from "@angular/router";
@@ -6,7 +6,8 @@ import {
   getAllPublishedData,
   getPublishedDataCount,
   getPage,
-  getPublishedDataPerPage
+  getPublishedDataPerPage,
+  getFilters
 } from "state-management/selectors/published-data.selectors";
 import {
   fetchAllPublishedDataAction,
@@ -16,13 +17,15 @@ import {
   PageChangeEvent,
   TableColumn
 } from "shared/modules/table/table.component";
+import { Subscription } from "rxjs";
+import * as rison from "rison";
 
 @Component({
   selector: "app-publisheddata-dashboard",
   templateUrl: "./publisheddata-dashboard.component.html",
   styleUrls: ["./publisheddata-dashboard.component.scss"]
 })
-export class PublisheddataDashboardComponent implements OnInit {
+export class PublisheddataDashboardComponent implements OnInit, OnDestroy {
   public publishedData$ = this.store.pipe(select(getAllPublishedData));
   public count$ = this.store.pipe(select(getPublishedDataCount));
   public currentPage$ = this.store.pipe(select(getPage));
@@ -34,9 +37,10 @@ export class PublisheddataDashboardComponent implements OnInit {
     { name: "creator", icon: "face", sort: false, inList: true },
     { name: "publicationYear", icon: "date_range", sort: false, inList: true },
     { name: "scicatUser", icon: "account_circle", sort: false, inList: true }
-
   ];
   paginate = true;
+
+  filtersSubscription: Subscription;
 
   onPageChange(event: PageChangeEvent) {
     this.store.dispatch(
@@ -53,5 +57,17 @@ export class PublisheddataDashboardComponent implements OnInit {
 
   ngOnInit() {
     this.store.dispatch(fetchAllPublishedDataAction());
+
+    this.filtersSubscription = this.store
+      .pipe(select(getFilters))
+      .subscribe(filters => {
+        this.router.navigate(["/publishedDatasets"], {
+          queryParams: { args: rison.encode(filters) }
+        });
+      });
+  }
+
+  ngOnDestroy() {
+    this.filtersSubscription.unsubscribe();
   }
 }

--- a/src/app/samples/sample-dashboard/sample-dashboard.component.spec.ts
+++ b/src/app/samples/sample-dashboard/sample-dashboard.component.spec.ts
@@ -11,7 +11,6 @@ import {
   TestBed,
   inject
 } from "@angular/core/testing";
-import { rootReducer } from "state-management/reducers/root.reducer";
 import {
   setTextFilterAction,
   changePageAction,
@@ -37,11 +36,7 @@ describe("SampleDashboardComponent", () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
-      imports: [
-        MatCardModule,
-        MatTableModule,
-        StoreModule.forRoot({ rootReducer })
-      ],
+      imports: [MatCardModule, MatTableModule, StoreModule.forRoot({})],
       declarations: [SampleDashboardComponent],
       providers: [DatePipe]
     });


### PR DESCRIPTION
## Description

Added router state to all dashboard components

## Motivation

Requested

## Changes:

* Added filter subscriptions that writes rison encoded filters to url for all dashboard components
* Removed obsolete rootReducer from the changed components spec files

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

