### PR TITLE
Added url path condition to logbook router state

### DIFF
--- a/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.spec.ts
+++ b/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.spec.ts
@@ -76,7 +76,7 @@ describe("DashboardComponent", () => {
   });
 
   describe("#applyRouterState()", () => {
-    it("should do nothing if properties logbook and filters are undefined", () => {
+    it("should do nothing if properties logbook and filters are undefined and url path does not contain `logbook`", () => {
       const navigateSpy = spyOn(router, "navigate");
 
       component.applyRouterState();
@@ -84,7 +84,7 @@ describe("DashboardComponent", () => {
       expect(navigateSpy).toHaveBeenCalledTimes(0);
     });
 
-    it("should call router.navigate if properties logbook and filters are defined", () => {
+    it("should call router.navigate if properties logbook and filters are defined  and url path contains `logbook`", () => {
       const navigateSpy = spyOn(router, "navigate");
 
       component.logbook = logbook;

--- a/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.ts
+++ b/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.ts
@@ -36,7 +36,11 @@ export class LogbooksDashboardComponent
   subscriptions: Subscription[] = [];
 
   applyRouterState() {
-    if (this.logbook && this.filters) {
+    if (
+      this.logbook &&
+      this.filters &&
+      this.route.snapshot.url[0].path === "logbooks"
+    ) {
       this.router.navigate(["/logbooks", this.logbook.name], {
         queryParams: { args: rison.encode(this.filters) }
       });

--- a/src/app/shared/MockStubs.ts
+++ b/src/app/shared/MockStubs.ts
@@ -78,7 +78,8 @@ export class MockActivatedRoute {
   // stub detail goes here
   snapshot = {
     queryParams: { returnUrl: "/" },
-    paramMap: convertToParamMap({ name: "string" })
+    paramMap: convertToParamMap({ name: "string" }),
+    url: [{ path: "logbooks" }]
   };
   params = of([{ id: 1 }]);
   queryParams = of([{ limit: 10 }]);


### PR DESCRIPTION
## Description

Fixed so that logbook router state no longer overrides and redirects from current path

## Motivation

Bug fix

## Changes:

* Added url path condition to logbook router state

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

