### PR TITLE
Updated logbooks table to show images

### DIFF
--- a/src/app/logbooks/logbooks-table/logbooks-table.component.html
+++ b/src/app/logbooks/logbooks-table/logbooks-table.component.html
@@ -76,7 +76,24 @@
       </mat-header-cell>
       <mat-cell *matCellDef="let logbook">
         <div fxLayout="column" *ngIf="logbook.messages.length > 0">
-          {{ logbook.messages[0].content.body }}
+          <div *ngIf="logbook.messages[0].content.msgtype !== 'm.image'">
+            <div
+              *ngIf="!logbook.messages[0].content.formatted_body"
+              style="white-space:pre-wrap"
+              [innerHTML]="logbook.messages[0].content.body"
+            ></div>
+            <div
+              *ngIf="logbook.messages[0].content.formatted_body"
+              [innerHTML]="logbook.messages[0].content.formatted_body"
+            ></div>
+          </div>
+          <div *ngIf="logbook.messages[0].content.msgtype === 'm.image'">
+            <img
+              src="{{ logbook.messages[0].content.url }}"
+              alt="{{ logbook.messages[0].content.body }}"
+              height="60px"
+            />
+          </div>
         </div>
         <div fxLayout="column" *ngIf="logbook.messages.length === 0">
           --

--- a/src/app/logbooks/logbooks-table/logbooks-table.component.ts
+++ b/src/app/logbooks/logbooks-table/logbooks-table.component.ts
@@ -29,11 +29,9 @@ export class LogbooksTableComponent implements OnInit, OnDestroy {
     this.logbooksSubscription = this.store
       .pipe(select(getLogbooks))
       .subscribe(logbooks => {
-        logbooks.forEach(logbook => {
-          const reversedMessages = logbook.messages.reverse();
-          logbook.messages = reversedMessages;
-        });
-        this.logbooks = logbooks;
+        if (logbooks) {
+          this.logbooks = logbooks;
+        }
       });
   }
 

--- a/src/app/state-management/reducers/logbooks.reducer.spec.ts
+++ b/src/app/state-management/reducers/logbooks.reducer.spec.ts
@@ -7,12 +7,16 @@ import { APP_DI_CONFIG } from "app-config.module";
 describe("LogbooksReducer", () => {
   describe("on fetchLogbooksComplete", () => {
     it("should set logbooks", () => {
-      const logbooks = [new Logbook()];
       const firstTestMessage = { content: "First message" };
       const secondTestMessage = { content: "Second message" };
-      logbooks.forEach(logbook => {
-        logbook.messages = [firstTestMessage, secondTestMessage];
-      });
+      const logbooks = [
+        new Logbook({
+          roomId: "testId",
+          name: "testName",
+          messages: [firstTestMessage, secondTestMessage]
+        })
+      ];
+
       const action = fromActions.fetchLogbooksCompleteAction({ logbooks });
       const state = logbooksReducer(initialLogbookState, action);
 

--- a/src/app/state-management/reducers/logbooks.reducer.ts
+++ b/src/app/state-management/reducers/logbooks.reducer.ts
@@ -10,13 +10,12 @@ import { APP_DI_CONFIG } from "app-config.module";
 const reducer = createReducer(
   initialLogbookState,
   on(fromActions.fetchLogbooksCompleteAction, (state, { logbooks }) => {
-    if (logbooks) {
-      logbooks.forEach(logbook => {
-        const descendingMessages = logbook.messages.reverse();
-        logbook.messages = descendingMessages;
-      });
-    }
-    return { ...state, logbooks };
+    const formattedLogbooks = logbooks.map(logbook => {
+      const descendingMessages = logbook.messages.reverse();
+      logbook.messages = descendingMessages;
+      return formatImageUrls(logbook);
+    });
+    return { ...state, logbooks: formattedLogbooks };
   }),
 
   on(fromActions.fetchLogbookCompleteAction, (state, { logbook }) => {
@@ -60,10 +59,9 @@ export function logbooksReducer(
 
 export function formatImageUrls(logbook: Logbook): Logbook {
   if (logbook && logbook.messages) {
-    const logbookCopy = { ...logbook } as Logbook;
-    logbookCopy.messages.forEach(message => {
+    logbook.messages.forEach(message => {
       if (message.content.msgtype === "m.image") {
-        if (message.content.info.hasOwnProperty("thumbnail_url")) {
+        if (message.content.info && message.content.info.hasOwnProperty("thumbnail_url")) {
           const externalThumbnailUrl = message.content.info.thumbnail_url.replace(
             "mxc://",
             `${APP_DI_CONFIG.synapseBaseUrl}/_matrix/media/r0/download/`
@@ -79,8 +77,6 @@ export function formatImageUrls(logbook: Logbook): Logbook {
         }
       }
     });
-    return logbookCopy;
-  } else {
-    return logbook;
   }
+  return logbook;
 }


### PR DESCRIPTION
## Description

Minor changes in logbooks table and logbooks reducer

## Motivation

Make logbooks from new server visible in scicat

## Changes:

* Added check in the formatImageUrls method in logbooks reducer
* Images now show up in logbooks table

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

