### PR TITLE
Removed copyimages and replaced with angular fileReplacements

### DIFF
--- a/CI/ESS/Dockerfile
+++ b/CI/ESS/Dockerfile
@@ -11,7 +11,6 @@ WORKDIR /catanie
 COPY package.json  /catanie
 RUN npm install
 COPY . /catanie/
-RUN ./CI/ESS/copyimages.sh
 RUN npx ng build --configuration=${env}
 
 FROM nginx:alpine

--- a/CI/ESS/Dockerfile.dmscdev
+++ b/CI/ESS/Dockerfile.dmscdev
@@ -16,7 +16,6 @@ WORKDIR /catanie
 COPY package.json  /catanie
 RUN npm install
 COPY . /catanie/
-RUN ./CI/ESS/copyimages.sh
 RUN npx ng build --configuration=${env}
 
 FROM nginx:alpine

--- a/CI/ESS/Dockerfile.dmscprod
+++ b/CI/ESS/Dockerfile.dmscprod
@@ -16,7 +16,6 @@ WORKDIR /catanie
 COPY package.json  /catanie
 RUN npm install
 COPY . /catanie/
-RUN ./CI/ESS/copyimages.sh
 RUN npx ng build --configuration=${env}
 
 FROM nginx:alpine

--- a/CI/ESS/Dockerfile.e2e
+++ b/CI/ESS/Dockerfile.e2e
@@ -13,7 +13,6 @@ RUN npm install
 RUN wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
 RUN chmod +x wait-for-it.sh
 COPY . /catanie/
-RUN ./CI/ESS/copyimages.sh
 RUN npx ng build --configuration=${env}
 
 FROM nginx:alpine

--- a/CI/ESS/Dockerfile.hub
+++ b/CI/ESS/Dockerfile.hub
@@ -16,7 +16,6 @@ WORKDIR /catanie
 COPY package.json  /catanie
 RUN npm install
 COPY . /catanie/
-RUN ./CI/ESS/copyimages.sh
 RUN npx ng build 
 
 FROM nginx:alpine

--- a/CI/ESS/copyimages.sh
+++ b/CI/ESS/copyimages.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-cp CI/ESS/ess-site.png src/assets/images/ess-site.png
-cp CI/ESS/esslogo.png src/assets/images/esslogo.png
-cp CI/ESS/favicon.ico src/favicon.ico

--- a/angular.json
+++ b/angular.json
@@ -54,6 +54,14 @@
                 {
                   "replace": "src/assets/images/ess-site.png",
                   "with": "CI/ESS/ess-site.png"
+                },
+                {
+                  "replace": "src/assets/images/esslogo.png",
+                  "with": "CI/ESS/esslogo.png"
+                },
+                {
+                  "replace": "src/favicon.ico",
+                  "with": "CI/ESS/favicon.ico"
                 }
               ],
               "serviceWorker": true
@@ -76,6 +84,14 @@
                 {
                   "replace": "src/assets/images/ess-site.png",
                   "with": "CI/ESS/ess-site.png"
+                },
+                {
+                  "replace": "src/assets/images/esslogo.png",
+                  "with": "CI/ESS/esslogo.png"
+                },
+                {
+                  "replace": "src/favicon.ico",
+                  "with": "CI/ESS/favicon.ico"
                 }
               ],
               "serviceWorker": true


### PR DESCRIPTION
## Description

Removed `copyimages.sh` and replaced with `angular.json` `fileReplacements`.

## Motivation

Requested

## Changes:

* Removed `CI/ESS/copyimages.sh`
* Removed `RUN ./CI/ESS/copyimages.sh` from Dockerfiles
* Added images in `CI/ESS/` to `angular.json` `fileReplacements` property

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

