### PR TITLE
Feature/dataset details update

### DIFF
--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -98,10 +98,10 @@
             <a class="related-link">{{ proposal.title }}</a>
           </td>
         </tr>
-        <tr *ngIf="dataset.sampleId as value" (click)="onClickSample(value)">
+        <tr *ngIf="sample" (click)="onClickSample(sample.sampleId)">
           <th><mat-icon> center_focus_weak </mat-icon> Sample</th>
           <td>
-            <a class="related-link">{{ value }}</a>
+            <a class="related-link">{{ sample.description }}</a>
           </td>
         </tr>
         <tr *ngIf="dataset.size as value">

--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -92,18 +92,20 @@
           <th><mat-icon> map </mat-icon> Version</th>
           <td>{{ value }}</td>
         </tr>
-        <tr *ngIf="proposal" (click)="onClickProposal(proposal.proposalId)">
-          <th><mat-icon> spa </mat-icon> Proposal</th>
-          <td>
-            <a class="related-link">{{ proposal.title }}</a>
-          </td>
-        </tr>
-        <tr *ngIf="sample" (click)="onClickSample(sample.sampleId)">
-          <th><mat-icon> center_focus_weak </mat-icon> Sample</th>
-          <td>
-            <a class="related-link">{{ sample.description }}</a>
-          </td>
-        </tr>
+        <ng-template [ngIf]="dataset.type === 'raw'">
+          <tr *ngIf="proposal" (click)="onClickProposal(proposal.proposalId)">
+            <th><mat-icon> spa </mat-icon> Proposal</th>
+            <td>
+              <a class="related-link">{{ proposal.title }}</a>
+            </td>
+          </tr>
+          <tr *ngIf="sample" (click)="onClickSample(sample.sampleId)">
+            <th><mat-icon> center_focus_weak </mat-icon> Sample</th>
+            <td>
+              <a class="related-link">{{ sample.description }}</a>
+            </td>
+          </tr>
+        </ng-template>
         <tr *ngIf="dataset.size as value">
           <th><mat-icon> save </mat-icon> Size</th>
           <td>{{ value | filesize }}</td>

--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -92,13 +92,10 @@
           <th><mat-icon> map </mat-icon> Version</th>
           <td>{{ value }}</td>
         </tr>
-        <tr
-          *ngIf="dataset.proposalId as value"
-          (click)="onClickProposal(value)"
-        >
+        <tr *ngIf="proposal" (click)="onClickProposal(proposal.proposalId)">
           <th><mat-icon> spa </mat-icon> Proposal</th>
           <td>
-            <a class="related-link">{{ value }}</a>
+            <a class="related-link">{{ proposal.title }}</a>
           </td>
         </tr>
         <tr *ngIf="dataset.sampleId as value" (click)="onClickSample(value)">

--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, Input, Output, EventEmitter } from "@angular/core";
-import { Attachment, Dataset } from "shared/sdk/models";
+import { Attachment, Dataset, Proposal } from "shared/sdk/models";
 import { APP_CONFIG, AppConfig } from "app-config.module";
 import { ENTER, COMMA, SPACE } from "@angular/cdk/keycodes";
 import { MatChipInputEvent } from "@angular/material";
@@ -16,9 +16,10 @@ import { MatChipInputEvent } from "@angular/material";
   styleUrls: ["./dataset-detail.component.scss"]
 })
 export class DatasetDetailComponent {
-  @Input("data") dataset: Dataset;
+  @Input() dataset: Dataset;
   @Input() datasetWithout: any;
   @Input() attachments: Attachment[];
+  @Input() proposal: Proposal;
 
   @Output() clickKeyword = new EventEmitter<string>();
   @Output() addKeyword = new EventEmitter<string>();

--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, Input, Output, EventEmitter } from "@angular/core";
-import { Attachment, Dataset, Proposal } from "shared/sdk/models";
+import { Attachment, Dataset, Proposal, Sample } from "shared/sdk/models";
 import { APP_CONFIG, AppConfig } from "app-config.module";
 import { ENTER, COMMA, SPACE } from "@angular/cdk/keycodes";
 import { MatChipInputEvent } from "@angular/material";
@@ -20,6 +20,7 @@ export class DatasetDetailComponent {
   @Input() datasetWithout: any;
   @Input() attachments: Attachment[];
   @Input() proposal: Proposal;
+  @Input() sample: Sample;
 
   @Output() clickKeyword = new EventEmitter<string>();
   @Output() addKeyword = new EventEmitter<string>();

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
@@ -34,9 +34,10 @@
       <div style="clear: both;"></div>
 
       <dataset-detail
-        [data]="dataset"
+        [dataset]="dataset"
         [datasetWithout]="datasetWithout$ | async"
         [attachments]="attachments$ | async"
+        [proposal]="proposal$ | async"
         (clickKeyword)="onClickKeyword($event)"
         (addKeyword)="onAddKeyword($event)"
         (removeKeyword)="onRemoveKeyword($event)"

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
@@ -38,6 +38,7 @@
         [datasetWithout]="datasetWithout$ | async"
         [attachments]="attachments$ | async"
         [proposal]="proposal$ | async"
+        [sample]="sample$ | async"
         (clickKeyword)="onClickKeyword($event)"
         (addKeyword)="onAddKeyword($event)"
         (removeKeyword)="onRemoveKeyword($event)"

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
@@ -246,7 +246,7 @@ export class DatasetDetailsDashboardComponent
         .subscribe((dataset: RawDataset | DerivedDataset) => {
           if (dataset) {
             this.dataset = dataset;
-            if ("proposalId" in dataset) {
+            if (dataset.type === "raw" && "proposalId" in dataset) {
               this.store.dispatch(
                 fetchProposalAction({ proposalId: dataset["proposalId"] })
               );

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
@@ -48,6 +48,8 @@ import { MatSlideToggleChange } from "@angular/material";
 import { fetchLogbookAction } from "state-management/actions/logbooks.actions";
 import { fetchProposalAction } from "state-management/actions/proposals.actions";
 import { getCurrentProposal } from "state-management/selectors/proposals.selectors";
+import { fetchSampleAction } from "state-management/actions/samples.actions";
+import { getCurrentSample } from "state-management/selectors/samples.selectors";
 
 @Component({
   selector: "dataset-details-dashboard",
@@ -61,6 +63,7 @@ export class DatasetDetailsDashboardComponent
   datablocks$ = this.store.pipe(select(getCurrentDatablocks));
   attachments$ = this.store.pipe(select(getCurrentAttachments));
   proposal$ = this.store.pipe(select(getCurrentProposal));
+  sample$ = this.store.pipe(select(getCurrentSample));
   isAdmin$ = this.store.pipe(select(getIsAdmin));
   jwt$: Observable<any>;
 
@@ -249,6 +252,11 @@ export class DatasetDetailsDashboardComponent
               );
               this.store.dispatch(
                 fetchLogbookAction({ name: dataset["proposalId"] })
+              );
+            }
+            if ("sampleId" in dataset) {
+              this.store.dispatch(
+                fetchSampleAction({ sampleId: dataset["sampleId"] })
               );
             }
           }

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
@@ -46,6 +46,8 @@ import { ReadFile } from "ngx-file-helpers";
 import { SubmitCaptionEvent } from "shared/modules/file-uploader/file-uploader.component";
 import { MatSlideToggleChange } from "@angular/material";
 import { fetchLogbookAction } from "state-management/actions/logbooks.actions";
+import { fetchProposalAction } from "state-management/actions/proposals.actions";
+import { getCurrentProposal } from "state-management/selectors/proposals.selectors";
 
 @Component({
   selector: "dataset-details-dashboard",
@@ -58,6 +60,7 @@ export class DatasetDetailsDashboardComponent
   origDatablocks$ = this.store.pipe(select(getCurrentOrigDatablocks));
   datablocks$ = this.store.pipe(select(getCurrentDatablocks));
   attachments$ = this.store.pipe(select(getCurrentAttachments));
+  proposal$ = this.store.pipe(select(getCurrentProposal));
   isAdmin$ = this.store.pipe(select(getIsAdmin));
   jwt$: Observable<any>;
 
@@ -140,31 +143,26 @@ export class DatasetDetailsDashboardComponent
     if (!confirm("Reset datablocks?")) {
       return null;
     }
-    this.store
-      .pipe(
-        select(getCurrentUser),
-        take(1)
-      )
-      .subscribe((user: User) => {
-        const job = new Job();
-        job.emailJobInitiator = user.email;
-        job.jobParams = {};
-        job.jobParams["username"] = user.username;
-        job.creationTime = new Date();
-        job.type = "reset";
-        const fileObj = {};
-        const fileList = [];
-        fileObj["pid"] = dataset["pid"];
-        if (dataset["datablocks"]) {
-          dataset["datablocks"].map(d => {
-            fileList.push(d["archiveId"]);
-          });
-        }
-        fileObj["files"] = fileList;
-        job.datasetList = [fileObj];
-        console.log(job);
-        this.store.dispatch(submitJobAction({ job }));
-      });
+    this.store.pipe(select(getCurrentUser), take(1)).subscribe((user: User) => {
+      const job = new Job();
+      job.emailJobInitiator = user.email;
+      job.jobParams = {};
+      job.jobParams["username"] = user.username;
+      job.creationTime = new Date();
+      job.type = "reset";
+      const fileObj = {};
+      const fileList = [];
+      fileObj["pid"] = dataset["pid"];
+      if (dataset["datablocks"]) {
+        dataset["datablocks"].map(d => {
+          fileList.push(d["archiveId"]);
+        });
+      }
+      fileObj["files"] = fileList;
+      job.datasetList = [fileObj];
+      console.log(job);
+      this.store.dispatch(submitJobAction({ job }));
+    });
   }
 
   onFileUploaderFilePicked(file: ReadFile) {
@@ -247,7 +245,10 @@ export class DatasetDetailsDashboardComponent
             this.dataset = dataset;
             if ("proposalId" in dataset) {
               this.store.dispatch(
-                fetchLogbookAction({ name: this.dataset["proposalId"] })
+                fetchProposalAction({ proposalId: dataset["proposalId"] })
+              );
+              this.store.dispatch(
+                fetchLogbookAction({ name: dataset["proposalId"] })
               );
             }
           }


### PR DESCRIPTION
## Description

Dataset details now displays proposal title instead of proposalId and sample description instead of sampleId.

## Motivation

Requested

## Changes:

* Added `fetchSample` and `fetchProposal` to dataset details dashboard component
* Added `proposal` and `sample` inputs to dataset details
* Added check `dataset.type === 'raw'` for displaying proposal title and sample description

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

