### PR TITLE
Set skip to 0 when applying a new filter

### DIFF
--- a/src/app/state-management/reducers/logbooks.reducer.spec.ts
+++ b/src/app/state-management/reducers/logbooks.reducer.spec.ts
@@ -70,17 +70,18 @@ describe("LogbooksReducer", () => {
   });
 
   describe("on setTextFilterAction", () => {
-    it("should set textSearch filter", () => {
+    it("should set textSearch filter and set skip filter to 0", () => {
       const textSearch = "test";
       const action = fromActions.setTextFilterAction({ textSearch });
       const state = logbooksReducer(initialLogbookState, action);
 
       expect(state.filters.textSearch).toEqual(textSearch);
+      expect(state.filters.skip).toEqual(0);
     });
   });
 
   describe("on setDisplayFiltersAction", () => {
-    it("should set showBotMessages, showImages and showUserMessages filters", () => {
+    it("should set showBotMessages, showImages and showUserMessages filters, and set skip filter to 0", () => {
       const showBotMessages = true;
       const showImages = true;
       const showUserMessages = false;
@@ -94,6 +95,7 @@ describe("LogbooksReducer", () => {
       expect(state.filters.showBotMessages).toEqual(showBotMessages);
       expect(state.filters.showImages).toEqual(showImages);
       expect(state.filters.showUserMessages).toEqual(showUserMessages);
+      expect(state.filters.skip).toEqual(0);
     });
   });
 

--- a/src/app/state-management/reducers/logbooks.reducer.ts
+++ b/src/app/state-management/reducers/logbooks.reducer.ts
@@ -34,7 +34,7 @@ const reducer = createReducer(
   }),
 
   on(fromActions.setTextFilterAction, (state, { textSearch }) => {
-    const filters = { ...state.filters, textSearch };
+    const filters = { ...state.filters, textSearch, skip: 0 };
     return { ...state, filters };
   }),
 
@@ -45,7 +45,8 @@ const reducer = createReducer(
         ...state.filters,
         showBotMessages,
         showImages,
-        showUserMessages
+        showUserMessages,
+        skip: 0
       };
       return { ...state, filters };
     }


### PR DESCRIPTION
## Description

Fixes logbook filtering bug created when pagination was added.

## Motivation

Bug fix

## Changes:

* Added `filters.skip: 0` to logbook filtering reducers

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

