### PR TITLE
Added actions and effects to persist user settings to backend

### DIFF
--- a/src/app/state-management/actions/datasets.actions.spec.ts
+++ b/src/app/state-management/actions/datasets.actions.spec.ts
@@ -409,6 +409,17 @@ describe("Dataset Actions", () => {
     });
   });
 
+  describe("setDatasetsLimitFilterAction", () => {
+    it("should create an action", () => {
+      const limit = 25;
+      const action = fromActions.setDatasetsLimitFilterAction({ limit });
+      expect({ ...action }).toEqual({
+        type: "[Dataset] Set Limit Filter",
+        limit
+      });
+    });
+  });
+
   describe("changePageAction", () => {
     it("should create an action", () => {
       const page = 0;

--- a/src/app/state-management/actions/datasets.actions.ts
+++ b/src/app/state-management/actions/datasets.actions.ts
@@ -154,6 +154,11 @@ export const clearSelectionAction = createAction("[Dataset] Clear Selection");
 
 // === Dataset Table Filtering ===
 
+export const setDatasetsLimitFilterAction = createAction(
+  "[Dataset] Set Limit Filter",
+  props<{ limit: number }>()
+);
+
 export const changePageAction = createAction(
   "[Dataset] Change Page",
   props<{ page: number; limit: number }>()

--- a/src/app/state-management/actions/jobs.actions.spec.ts
+++ b/src/app/state-management/actions/jobs.actions.spec.ts
@@ -107,6 +107,14 @@ describe("Job Actions", () => {
     });
   });
 
+  describe("setJobsLimitFilterAction", () => {
+    it("should create an action", () => {
+      const limit = 25;
+      const action = fromActions.setJobsLimitFilterAction({ limit });
+      expect({ ...action }).toEqual({ type: "[Job] Set Limit Filter", limit });
+    });
+  });
+
   describe("changePageAction", () => {
     it("should create an action", () => {
       const page = 1;

--- a/src/app/state-management/actions/jobs.actions.ts
+++ b/src/app/state-management/actions/jobs.actions.ts
@@ -43,6 +43,11 @@ export const setJobViewModeAction = createAction(
   props<{ mode: object }>()
 );
 
+export const setJobsLimitFilterAction = createAction(
+  "[Job] Set Limit Filter",
+  props<{ limit: number }>()
+);
+
 export const changePageAction = createAction(
   "[Job] Change Page",
   props<{ page: number; limit: number }>()

--- a/src/app/state-management/effects/datasets.effects.spec.ts
+++ b/src/app/state-management/effects/datasets.effects.spec.ts
@@ -20,7 +20,8 @@ import {
 import {
   loadingAction,
   loadingCompleteAction,
-  addCustomColumnsAction
+  addCustomColumnsAction,
+  updateUserSettingsAction
 } from "state-management/actions/user.actions";
 import { ScientificCondition } from "state-management/models";
 
@@ -181,6 +182,21 @@ describe("DatasetEffects", () => {
 
       const expected = cold("--b", { b: outcome });
       expect(effects.fetchMetadataKeys$).toBeObservable(expected);
+    });
+  });
+
+  describe("updateUserDatasetsLimit$", () => {
+    it("should result in an updateUserSettingsAction", () => {
+      const page = 0;
+      const limit = 25;
+      const property = { datasetCount: limit };
+      const action = fromActions.changePageAction({ page, limit });
+      const outcome = updateUserSettingsAction({ property });
+
+      actions = hot("-a", { a: action });
+
+      const expected = cold("-b", { b: outcome });
+      expect(effects.updateUserDatasetsLimit$).toBeObservable(expected);
     });
   });
 

--- a/src/app/state-management/effects/datasets.effects.ts
+++ b/src/app/state-management/effects/datasets.effects.ts
@@ -23,7 +23,8 @@ import {
   logoutCompleteAction,
   loadingAction,
   loadingCompleteAction,
-  addCustomColumnsAction
+  addCustomColumnsAction,
+  updateUserSettingsAction
 } from "state-management/actions/user.actions";
 
 @Injectable()
@@ -84,6 +85,15 @@ export class DatasetEffects {
           catchError(() => of(fromActions.fetchMetadataKeysFailedAction()))
         );
       })
+    )
+  );
+
+  updateUserDatasetsLimit$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(fromActions.changePageAction),
+      map(({ limit }) =>
+        updateUserSettingsAction({ property: { datasetCount: limit } })
+      )
     )
   );
 

--- a/src/app/state-management/effects/jobs.effects.spec.ts
+++ b/src/app/state-management/effects/jobs.effects.spec.ts
@@ -10,7 +10,8 @@ import { hot, cold } from "jasmine-marbles";
 import {
   showMessageAction,
   loadingAction,
-  loadingCompleteAction
+  loadingCompleteAction,
+  updateUserSettingsAction
 } from "state-management/actions/user.actions";
 import { MessageType } from "state-management/models";
 
@@ -197,6 +198,21 @@ describe("JobEffects", () => {
 
       const expected = cold("--b", { b: outcome });
       expect(effects.fetchCount$).toBeObservable(expected);
+    });
+  });
+
+  describe("updateUserJobsLimit$", () => {
+    it("should result in an updateUserSettingsAction", () => {
+      const page = 0;
+      const limit = 25;
+      const property = { jobCount: limit };
+      const action = fromActions.changePageAction({ page, limit });
+      const outcome = updateUserSettingsAction({ property });
+
+      actions = hot("-a", { a: action });
+
+      const expected = cold("-b", { b: outcome });
+      expect(effects.updateUserJobsLimit$).toBeObservable(expected);
     });
   });
 

--- a/src/app/state-management/effects/jobs.effects.ts
+++ b/src/app/state-management/effects/jobs.effects.ts
@@ -10,7 +10,8 @@ import { MessageType } from "state-management/models";
 import {
   showMessageAction,
   loadingAction,
-  loadingCompleteAction
+  loadingCompleteAction,
+  updateUserSettingsAction
 } from "state-management/actions/user.actions";
 
 @Injectable()
@@ -51,6 +52,15 @@ export class JobEffects {
           ),
           catchError(() => of(fromActions.fetchCountFailedAction()))
         )
+      )
+    )
+  );
+
+  updateUserJobsLimit$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(fromActions.changePageAction),
+      map(({ limit }) =>
+        updateUserSettingsAction({ property: { jobCount: limit } })
       )
     )
   );

--- a/src/app/state-management/effects/user.effects.spec.ts
+++ b/src/app/state-management/effects/user.effects.spec.ts
@@ -22,6 +22,8 @@ import {
   getColumns,
   getCurrentUser
 } from "state-management/selectors/user.selectors";
+import { setDatasetsLimitFilterAction } from "state-management/actions/datasets.actions";
+import { setJobsLimitFilterAction } from "state-management/actions/jobs.actions";
 
 describe("UserEffects", () => {
   let actions: Observable<any>;
@@ -438,6 +440,30 @@ describe("UserEffects", () => {
 
       const expected = cold("--b", { b: outcome });
       expect(effects.fetchUserSettings$).toBeObservable(expected);
+    });
+  });
+
+  describe("setLimitFilters$", () => {
+    it("should result in a setDatasetsLimitFilterAction and a setJobsLimitFilterAction", () => {
+      const userSettings = {
+        columns: [],
+        datasetCount: 10,
+        jobCount: 10
+      } as UserSetting;
+      const action = fromActions.fetchUserSettingsCompleteAction({
+        userSettings
+      });
+      const outcome1 = setDatasetsLimitFilterAction({
+        limit: userSettings.datasetCount
+      });
+      const outcome2 = setJobsLimitFilterAction({
+        limit: userSettings.jobCount
+      });
+
+      actions = hot("-a", { a: action });
+
+      const expected = cold("-(bc)", { b: outcome1, c: outcome2 });
+      expect(effects.setLimitFilters$).toBeObservable(expected);
     });
   });
 

--- a/src/app/state-management/effects/user.effects.ts
+++ b/src/app/state-management/effects/user.effects.ts
@@ -18,7 +18,8 @@ import {
   filter,
   tap,
   withLatestFrom,
-  distinctUntilChanged
+  distinctUntilChanged,
+  mergeMap
 } from "rxjs/operators";
 import { of } from "rxjs";
 import { MessageType } from "state-management/models";
@@ -27,6 +28,8 @@ import {
   getColumns,
   getCurrentUser
 } from "state-management/selectors/user.selectors";
+import { setDatasetsLimitFilterAction } from "state-management/actions/datasets.actions";
+import { setJobsLimitFilterAction } from "state-management/actions/jobs.actions";
 
 @Injectable()
 export class UserEffects {
@@ -204,6 +207,16 @@ export class UserEffects {
           catchError(() => of(fromActions.fetchUserSettingsFailedAction()))
         )
       )
+    )
+  );
+
+  setLimitFilters$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(fromActions.fetchUserSettingsCompleteAction),
+      mergeMap(({ userSettings }) => [
+        setDatasetsLimitFilterAction({ limit: userSettings.datasetCount }),
+        setJobsLimitFilterAction({ limit: userSettings.jobCount })
+      ])
     )
   );
 

--- a/src/app/state-management/reducers/datasets.reducer.spec.ts
+++ b/src/app/state-management/reducers/datasets.reducer.spec.ts
@@ -208,6 +208,17 @@ describe("DatasetsReducer", () => {
     });
   });
 
+  describe("on setDatasetsLimitFilterAction", () => {
+    it("should set limit filter and set skip to 0", () => {
+      const limit = 10;
+      const action = fromActions.setDatasetsLimitFilterAction({ limit });
+      const state = fromDatasets.datasetsReducer(initialDatasetState, action);
+
+      expect(state.filters.limit).toEqual(limit);
+      expect(state.filters.skip).toEqual(0);
+    });
+  });
+
   describe("on changePageAction", () => {
     it("should set filters limit and skip", () => {
       const page = 1;

--- a/src/app/state-management/reducers/datasets.reducer.ts
+++ b/src/app/state-management/reducers/datasets.reducer.ts
@@ -113,6 +113,11 @@ const reducer = createReducer(
     selectedSets: []
   })),
 
+  on(fromActions.setDatasetsLimitFilterAction, (state, { limit }) => {
+    const filters = { ...state.filters, limit, skip: 0 };
+    return { ...state, filters };
+  }),
+
   on(fromActions.changePageAction, (state, { page, limit }) => {
     const skip = page * limit;
     const filters = { ...state.filters, skip, limit };

--- a/src/app/state-management/reducers/jobs.reducer.spec.ts
+++ b/src/app/state-management/reducers/jobs.reducer.spec.ts
@@ -1,7 +1,7 @@
 import { jobsReducer } from "./jobs.reducer";
 import { JobInterface, Job } from "shared/sdk";
-import { JobsState } from "state-management/state/jobs.store";
 import * as fromActions from "../actions/jobs.actions";
+import { initialJobsState } from "state-management/state/jobs.store";
 
 const data: JobInterface = {
   id: "testId",
@@ -10,24 +10,6 @@ const data: JobInterface = {
   datasetList: {}
 };
 const job = new Job(data);
-
-const jobFilters = {
-  mode: null,
-  sortField: "creationTime:desc",
-  skip: 0,
-  limit: 50
-};
-
-const initialJobsState: JobsState = {
-  jobs: [],
-  currentJob: job,
-
-  totalCount: 0,
-
-  submitError: undefined,
-
-  filters: jobFilters
-};
 
 describe("jobsReducer", () => {
   describe("on fetchJobsCompleteAction", () => {
@@ -85,6 +67,17 @@ describe("jobsReducer", () => {
       const state = jobsReducer(initialJobsState, action);
 
       expect(state.filters.mode).toEqual(mode);
+      expect(state.filters.skip).toEqual(0);
+    });
+  });
+
+  describe("on setJobsLimitFilterAction", () => {
+    it("should set limit filter and set skip to 0", () => {
+      const limit = 10;
+      const action = fromActions.setJobsLimitFilterAction({ limit });
+      const state = jobsReducer(initialJobsState, action);
+
+      expect(state.filters.limit).toEqual(limit);
       expect(state.filters.skip).toEqual(0);
     });
   });

--- a/src/app/state-management/reducers/jobs.reducer.ts
+++ b/src/app/state-management/reducers/jobs.reducer.ts
@@ -33,6 +33,11 @@ const reducer = createReducer(
     filters: { ...state.filters, mode, skip: 0 }
   })),
 
+  on(fromActions.setJobsLimitFilterAction, (state, { limit }) => {
+    const filters = { ...state.filters, limit, skip: 0 };
+    return { ...state, filters };
+  }),
+
   on(fromActions.changePageAction, (state, { page, limit }) => {
     const skip = page * limit;
     const filters = { ...state.filters, skip, limit };


### PR DESCRIPTION
## Description

Added datasets limit and jobs limit to the persisted user settings.

## Motivation

Requested.

## Changes:

* Added actions `setDatasetsLimitFilterAction` and `setJobsLimitFilterAction`
* Added user effect `setLimitFilters$` that triggers the two actions above after fetching user settings from catamel
* Added effects `updateUserDatasetsLimit$` and `updateUserJobsLimit$` that triggers `updateUserSettingsAction` and persists changes to catamel

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

