### PR TITLE
Updated sdk + file uploader

### DIFF
--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.spec.ts
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.spec.ts
@@ -350,6 +350,7 @@ describe("DetailsDashboardComponent", () => {
     it("should dispatch an AddAttchment action if fileCount is larger than zero", () => {
       dispatchSpy = spyOn(store, "dispatch");
 
+      component.user = new User();
       component.dataset = new Dataset();
       component.pickedFile = {
         name: "test",

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
@@ -169,7 +169,12 @@ export class DatasetDetailsDashboardComponent
       this.attachment = {
         thumbnail: this.pickedFile.content,
         caption: this.pickedFile.name,
-        creationTime: new Date(),
+        ownerGroup: this.dataset.ownerGroup,
+        accessGroups: this.dataset.accessGroups,
+        createdBy: this.user.username,
+        updatedBy: this.user.username,
+        createdAt: new Date(),
+        updatedAt: new Date(),
         id: null,
         dataset: this.dataset,
         datasetId: this.dataset.pid,

--- a/src/app/samples/sample-detail/sample-detail.component.spec.ts
+++ b/src/app/samples/sample-detail/sample-detail.component.spec.ts
@@ -24,7 +24,7 @@ import {
   removeAttachmentAction,
   addAttachmentAction
 } from "state-management/actions/samples.actions";
-import { Dataset, Sample } from "shared/sdk";
+import { Dataset, Sample, User } from "shared/sdk";
 import { SharedCatanieModule } from "shared/shared.module";
 import { DatePipe, SlicePipe } from "@angular/common";
 import { FileSizePipe } from "shared/pipes/filesize.pipe";
@@ -164,6 +164,7 @@ describe("SampleDetailComponent", () => {
     it("should dispatch an addAttachmentAction if filecount > 0", () => {
       dispatchSpy = spyOn(store, "dispatch");
 
+      component.user = new User();
       component.sample = new Sample();
       component.pickedFile = {
         name: "test",

--- a/src/app/samples/sample-detail/sample-detail.component.ts
+++ b/src/app/samples/sample-detail/sample-detail.component.ts
@@ -1,7 +1,7 @@
 import { ActivatedRoute, Router } from "@angular/router";
 import { Component, OnDestroy, OnInit, Inject } from "@angular/core";
 import { Subscription } from "rxjs";
-import { Sample, Dataset, Attachment } from "../../shared/sdk/models";
+import { Sample, Dataset, Attachment, User } from "../../shared/sdk/models";
 import {
   getCurrentSample,
   getDatasets,
@@ -29,6 +29,7 @@ import {
 import { APP_CONFIG, AppConfig } from "app-config.module";
 import { ReadFile } from "ngx-file-helpers";
 import { SubmitCaptionEvent } from "shared/modules/file-uploader/file-uploader.component";
+import { getCurrentUser } from "state-management/selectors/user.selectors";
 
 @Component({
   selector: "app-sample-detail",
@@ -42,6 +43,7 @@ export class SampleDetailComponent implements OnInit, OnDestroy {
   datasetsCount$ = this.store.pipe(select(getDatasetsCount));
 
   sample: Sample;
+  user: User;
   pickedFile: ReadFile;
   attachment: Attachment;
 
@@ -96,7 +98,12 @@ export class SampleDetailComponent implements OnInit, OnDestroy {
       this.attachment = {
         thumbnail: this.pickedFile.content,
         caption: this.pickedFile.name,
-        creationTime: new Date(),
+        ownerGroup: this.sample.ownerGroup,
+        accessGroups: this.sample.accessGroups,
+        createdBy: this.user.username,
+        updatedBy: this.user.username,
+        createdAt: new Date(),
+        updatedAt: new Date(),
         id: null,
         sample: this.sample,
         sampleId: this.sample.sampleId,
@@ -162,6 +169,12 @@ export class SampleDetailComponent implements OnInit, OnDestroy {
     this.subscriptions.push(
       this.store.pipe(select(getDatasets)).subscribe(datasets => {
         this.tableData = this.formatTableData(datasets);
+      })
+    );
+
+    this.subscriptions.push(
+      this.store.pipe(select(getCurrentUser)).subscribe(user => {
+        this.user = user;
       })
     );
 

--- a/src/app/shared/modules/file-uploader/file-uploader.component.html
+++ b/src/app/shared/modules/file-uploader/file-uploader.component.html
@@ -42,7 +42,7 @@
     ngxFilePicker
     [readMode]="readMode"
     multiple
-    accept="image/*"
+    accept="image/*,application/pdf"
     (readStart)="onReadStart($event)"
     (filePick)="onFilePicked($event)"
     (readEnd)="onReadEnd($event)"

--- a/src/app/shared/modules/file-uploader/file-uploader.component.html
+++ b/src/app/shared/modules/file-uploader/file-uploader.component.html
@@ -21,7 +21,7 @@
         ngxFilePicker
         [readMode]="readMode"
         multiple
-        accept="image/*"
+        accept="image/*,application/pdf"
         (readStart)="onReadStart($event)"
         (filePick)="onFilePicked($event)"
         (readEnd)="onReadEnd($event)"

--- a/src/app/shared/sdk/models/Attachment.ts
+++ b/src/app/shared/sdk/models/Attachment.ts
@@ -9,13 +9,18 @@ declare var Object: any;
 export interface AttachmentInterface {
   "thumbnail": string;
   "caption"?: string;
-  "creationTime"?: Date;
+  "ownerGroup": string;
+  "accessGroups"?: Array<any>;
+  "createdBy"?: string;
+  "updatedBy"?: string;
   "id"?: any;
   "datasetId"?: string;
   "sampleId"?: string;
   "proposalId"?: string;
   "rawDatasetId"?: string;
   "derivedDatasetId"?: string;
+  "createdAt"?: Date;
+  "updatedAt"?: Date;
   dataset?: Dataset;
   sample?: Sample;
   proposal?: Proposal;
@@ -24,13 +29,18 @@ export interface AttachmentInterface {
 export class Attachment implements AttachmentInterface {
   "thumbnail": string;
   "caption": string;
-  "creationTime": Date;
+  "ownerGroup": string;
+  "accessGroups": Array<any>;
+  "createdBy": string;
+  "updatedBy": string;
   "id": any;
   "datasetId": string;
   "sampleId": string;
   "proposalId": string;
   "rawDatasetId": string;
   "derivedDatasetId": string;
+  "createdAt": Date;
+  "updatedAt": Date;
   dataset: Dataset;
   sample: Sample;
   proposal: Proposal;
@@ -77,9 +87,21 @@ export class Attachment implements AttachmentInterface {
           type: 'string',
           default: ''
         },
-        "creationTime": {
-          name: 'creationTime',
-          type: 'Date'
+        "ownerGroup": {
+          name: 'ownerGroup',
+          type: 'string'
+        },
+        "accessGroups": {
+          name: 'accessGroups',
+          type: 'Array&lt;any&gt;'
+        },
+        "createdBy": {
+          name: 'createdBy',
+          type: 'string'
+        },
+        "updatedBy": {
+          name: 'updatedBy',
+          type: 'string'
         },
         "id": {
           name: 'id',
@@ -104,6 +126,14 @@ export class Attachment implements AttachmentInterface {
         "derivedDatasetId": {
           name: 'derivedDatasetId',
           type: 'string'
+        },
+        "createdAt": {
+          name: 'createdAt',
+          type: 'Date'
+        },
+        "updatedAt": {
+          name: 'updatedAt',
+          type: 'Date'
         },
       },
       relations: {

--- a/src/app/shared/sdk/services/custom/Attachment.ts
+++ b/src/app/shared/sdk/services/custom/Attachment.ts
@@ -189,6 +189,35 @@ export class AttachmentApi extends BaseLoopBackApi {
   }
 
   /**
+   * Check if data is valid according to a schema
+   *
+   * @param {object} data Request data.
+   *
+   * This method expects a subset of model properties as request parameters.
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Attachment` object.)
+   * </em>
+   */
+  public isValid(ownableItem: any = {}, customHeaders?: Function): Observable<any> {
+    let _method: string = "POST";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/Attachments/isValid";
+    let _routeParams: any = {};
+    let _postBody: any = {
+      ownableItem: ownableItem
+    };
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
    * The name of the model represented by this $resource,
    * i.e. `Attachment`.
    */

--- a/src/app/state-management/reducers/proposals.reducer.spec.ts
+++ b/src/app/state-management/reducers/proposals.reducer.spec.ts
@@ -90,8 +90,7 @@ describe("ProposalsReducer", () => {
 
   describe("on updateAttachmentCaptionCompleteAction", () => {
     it("should set attachments of currentProposal", () => {
-      const attachmentId = "testId";
-      const attachment = new Attachment({ id: attachmentId, thumbnail: "" });
+      const attachment = new Attachment();
       initialProposalsState.currentProposal = proposal;
       initialProposalsState.currentProposal.attachments = [attachment];
 
@@ -107,7 +106,8 @@ describe("ProposalsReducer", () => {
   describe("on removeAttachmentCompleteAction", () => {
     it("should remove an attachment from currentProposal", () => {
       const attachmentId = "testId";
-      const attachment = new Attachment({ id: attachmentId, thumbnail: "" });
+      const attachment = new Attachment();
+      attachment.id = attachmentId;
       initialProposalsState.currentProposal = proposal;
       initialProposalsState.currentProposal.attachments = [attachment];
 


### PR DESCRIPTION
## Description

Updated sdk and file uploader to comlply with catamel updated of attachment model. Also extended file upoader to allow upload of pdf files.

## Motivation

Required after merging catamel pr [#277](https://github.com/SciCatProject/catamel/pull/277)

## Changes:

* Updated sdk with new changes to Attachment model in catamel
* Updated file uploader to allow pdf files
* Updated file upload logic in sample details and dataset details dashboard to comply with Attachment model changes

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [x] Requires update of catamel API?

