### PR TITLE
Disallowing invalid form for creating new samples

### DIFF
--- a/src/app/samples/sample-dialog/sample-dialog.component.html
+++ b/src/app/samples/sample-dialog/sample-dialog.component.html
@@ -6,6 +6,7 @@
       id="descriptionInput"
       placeholder="Sample Description"
       formControlName="description"
+      required="required"
     />
   </mat-form-field>
   <mat-form-field>
@@ -31,11 +32,12 @@
       id="groupInput"
       placeholder="Owner Group"
       formControlName="ownerGroup"
+      required="required"
     />
     <mat-hint align="end">Use a group you have access to</mat-hint>
   </mat-form-field>
 </mat-dialog-content>
 <div mat-dialog-actions>
   <button mat-button (click)="close()">Close</button>
-  <button mat-button (click)="save()">Save</button>
+  <button mat-button [disabled]="!form.valid" (click)="save()">Save</button>
 </div>

--- a/src/app/samples/sample-dialog/sample-dialog.component.ts
+++ b/src/app/samples/sample-dialog/sample-dialog.component.ts
@@ -73,7 +73,7 @@ export class SampleDialogComponent implements OnInit, OnDestroy {
 
     this.form = this.fb.group({
       description: [description, Validators.required],
-      sampleCharacteristics: [sampleCharacteristics, Validators.required],
+      sampleCharacteristics: [sampleCharacteristics],
       ownerGroup: [ownerGroup, Validators.required]
     });
   }


### PR DESCRIPTION
## Description

Added a simple `[disabled]="!form.valid"` to disable the Save button when trying to submit a new Sample.

I've removed the `Validators.required` from `sampleCharacteristics` because its not required. An empty field is already handled by the logic.

## Motivation

Previously the client did not checked, if the form that is submitted is valid, which eventually were caught by loopback's validation without users knowledge.

## Fixes:

* Disallowing invalid form for creating new samples

## Changes:

* Save button is only enabled when the form is valid

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [X] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

