### PR TITLE
Remove store devtools for prod

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -87,6 +87,10 @@
               "buildOptimizer": true,
               "fileReplacements": [
                 {
+                  "replace": "src/app/build-specifics/index.ts",
+                  "with": "src/app/build-specifics/index.prod.ts"
+                },
+                {
                   "replace": "src/environments/environment.ts",
                   "with": "src/environments/environment.e2e.ts"
                 },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,6 +23,7 @@ import { StoreModule } from "@ngrx/store";
 import { UserApi } from "shared/sdk/services";
 import { UsersModule } from "users/users.module";
 import { routerReducer } from "@ngrx/router-store";
+import { extModules } from './build-specifics';
 
 import {
   MatMenuModule,
@@ -93,6 +94,7 @@ import { InstrumentsModule } from "./instruments/instruments.module";
         }
       }
     ),
+    extModules,
     RouterModule.forRoot(routes, { useHash: false }),
     StoreDevtoolsModule.instrument({
       maxAge: 25, //  Retains last 25 states

--- a/src/app/build-specifics/index.prod.ts
+++ b/src/app/build-specifics/index.prod.ts
@@ -1,0 +1,1 @@
+export const extModules = [];

--- a/src/app/build-specifics/index.ts
+++ b/src/app/build-specifics/index.ts
@@ -1,0 +1,7 @@
+import { StoreDevtoolsModule } from '@ngrx/store-devtools';
+
+export const extModules = [
+    StoreDevtoolsModule.instrument({
+        maxAge: 25
+    })
+];


### PR DESCRIPTION
## Description
Remove store devtools for prod. Should help to cope with problems when browser is running out of memory.

## Fixes:

#643 (partly ?)

