### PR TITLE
Also datablock file infos needs be removed from JSON display

### DIFF
--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
@@ -10,7 +10,7 @@ import { Store, select } from "@ngrx/store";
 import { Dataset, UserApi, User, Job, Attachment } from "shared/sdk";
 import {
   getCurrentDataset,
-  getCurrentDatasetWithoutOrigData,
+  getCurrentDatasetWithoutFileInfo,
   getCurrentOrigDatablocks,
   getCurrentDatablocks,
   getCurrentAttachments,
@@ -50,7 +50,7 @@ import { getCurrentSample } from "state-management/selectors/samples.selectors";
 })
 export class DatasetDetailsDashboardComponent
   implements OnInit, OnDestroy, AfterViewChecked {
-  datasetWithout$ = this.store.pipe(select(getCurrentDatasetWithoutOrigData));
+  datasetWithout$ = this.store.pipe(select(getCurrentDatasetWithoutFileInfo));
   origDatablocks$ = this.store.pipe(select(getCurrentOrigDatablocks));
   datablocks$ = this.store.pipe(select(getCurrentDatablocks));
   attachments$ = this.store.pipe(select(getCurrentAttachments));

--- a/src/app/state-management/selectors/datasets.selectors.spec.ts
+++ b/src/app/state-management/selectors/datasets.selectors.spec.ts
@@ -72,13 +72,13 @@ describe("test dataset selectors", () => {
     });
   });
 
-  describe("getCurrentDatasetWithoutOrigData", () => {
+  describe("getCurrentDatasetWithoutFileInfo", () => {
     it("should get the current dataset without origDatablocks", () => {
       const datasetWithout = { ...dataset };
       delete datasetWithout.origdatablocks;
 
       expect(
-        fromDatasetSelectors.getCurrentDatasetWithoutOrigData.projector(
+        fromDatasetSelectors.getCurrentDatasetWithoutFileInfo.projector(
           initialDatasetState
         )
       ).toEqual(datasetWithout);

--- a/src/app/state-management/selectors/datasets.selectors.ts
+++ b/src/app/state-management/selectors/datasets.selectors.ts
@@ -23,10 +23,10 @@ export const getCurrentDataset = createSelector(
   state => state.currentSet
 );
 
-export const getCurrentDatasetWithoutOrigData = createSelector(
+export const getCurrentDatasetWithoutFileInfo = createSelector(
   getDatasetState,
   state => {
-    const { origdatablocks, ...theRest } = state.currentSet;
+    const { origdatablocks, datablocks, ...theRest } = state.currentSet;
     return theRest;
   }
 );


### PR DESCRIPTION
## Description

Avoid display of large file arrays in JSON metadata display

## Motivation

Stabilize browser by avoiding display of large of large filearrays i

## Changes:

* in additon to origdatablocks the datablocks information is removed as well

