### PR TITLE
Add datasets guard for redirect to anonymous view

### DIFF
--- a/src/app/app-routing/app-routing.module.ts
+++ b/src/app/app-routing/app-routing.module.ts
@@ -44,6 +44,7 @@ import { AnonymousLayoutComponent } from "_layout/anonymous-layout/anonymous-lay
 import { JobsGuard } from "app-routing/jobs.guard";
 import { PoliciesGuard } from "app-routing/policies.guard";
 import { LogbookGuard } from "app-routing/logbook.guard";
+import { DatasetsGuard } from "./datasets.guard";
 
 export const routes: Routes = [
   {
@@ -103,7 +104,7 @@ export const routes: Routes = [
       {
         path: "datasets",
         component: DashboardComponent,
-        canActivate: [AuthGuard],
+        canActivate: [DatasetsGuard],
       },
       {
         path: "datasets/batch",
@@ -113,17 +114,17 @@ export const routes: Routes = [
       {
         path: "datasets/:id",
         component: DatasetDetailsDashboardComponent,
-        canActivate: [AuthGuard],
+        canActivate: [DatasetsGuard],
       },
       {
         path: "datasets/:id/datablocks",
         component: DatablocksComponent,
-        canActivate: [AuthGuard],
+        canActivate: [DatasetsGuard],
       },
       {
         path: "datasets/:id/datafiles",
         component: DatafilesComponent,
-        canActivate: [AuthGuard],
+        canActivate: [DatasetsGuard],
       },
       {
         path: "instruments",

--- a/src/app/app-routing/datasets.guard.ts
+++ b/src/app/app-routing/datasets.guard.ts
@@ -1,0 +1,29 @@
+import { Injectable } from "@angular/core";
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  Router,
+  RouterStateSnapshot,
+} from "@angular/router";
+import { UserApi } from "shared/sdk";
+
+@Injectable({
+  providedIn: "root",
+})
+export class DatasetsGuard implements CanActivate {
+  constructor(private router: Router, private userApi: UserApi) {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Promise<boolean> {
+    return this.userApi
+      .getCurrent()
+      .toPromise()
+      .catch(() => {
+        this.router.navigateByUrl("/anonymous" + state.url);
+        return false;
+      })
+      .then(() => true);
+  }
+}

--- a/src/app/app-routing/datasets.guard.ts
+++ b/src/app/app-routing/datasets.guard.ts
@@ -5,25 +5,32 @@ import {
   Router,
   RouterStateSnapshot,
 } from "@angular/router";
-import { UserApi } from "shared/sdk";
+import { select, Store } from "@ngrx/store";
+import { Observable } from "rxjs";
+import { map } from "rxjs/operators";
+import { User } from "shared/sdk";
+import { getIsLoggedIn } from "state-management/selectors/user.selectors";
 
 @Injectable({
   providedIn: "root",
 })
 export class DatasetsGuard implements CanActivate {
-  constructor(private router: Router, private userApi: UserApi) {}
+  constructor(private router: Router, private store: Store<User>) {}
 
   canActivate(
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
-  ): Promise<boolean> {
-    return this.userApi
-      .getCurrent()
-      .toPromise()
-      .catch(() => {
+  ): Observable<boolean> {
+    return this.store.pipe(
+      select(getIsLoggedIn),
+      map((isLoggedIn) => {
+        if (isLoggedIn) {
+          return true;
+        }
+
         this.router.navigateByUrl("/anonymous" + state.url);
         return false;
       })
-      .then(() => true);
+    );
   }
 }


### PR DESCRIPTION
## Description

Add redirect guard for datasets that redirects an unauthenticated user to the anonymous version of the datasets view.

## Motivation

A user should be able to share links to public datasets with users that don't have a scicat account.

## Changes:

* Add Datasets guard
* Implement Datasets guard for `/datasets` endpoints

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

