### PR TITLE
Feature/dataset history csv export

### DIFF
--- a/src/app/datasets/dataset-lifecycle/dataset-lifecycle.component.html
+++ b/src/app/datasets/dataset-lifecycle/dataset-lifecycle.component.html
@@ -55,6 +55,10 @@
           History
         </mat-card-header>
 
+        <button mat-icon-button (click)="downloadCsv()">
+          <mat-icon>cloud_download</mat-icon>
+        </button>
+
         <mat-paginator
           [length]="historyItemsCount"
           [pageIndex]="currentPage"

--- a/src/app/datasets/dataset-lifecycle/dataset-lifecycle.component.html
+++ b/src/app/datasets/dataset-lifecycle/dataset-lifecycle.component.html
@@ -22,7 +22,8 @@
             </tr>
             <tr
               *ngIf="
-                dataset.isPublished && dataset.datasetlifecycle.publishedOn as value
+                dataset.isPublished &&
+                dataset.datasetlifecycle.publishedOn as value
               "
             >
               <th><mat-icon> event_available </mat-icon> Publication Date</th>
@@ -55,18 +56,26 @@
           History
         </mat-card-header>
 
-        <button mat-icon-button (click)="downloadCsv()">
-          <mat-icon>cloud_download</mat-icon>
-        </button>
+        <div fxLayout="row" fxLayoutAlign="space-evenly end">
+          <button
+            mat-stroked-button
+            class="download-button"
+            (click)="downloadCsv()"
+          >
+            <mat-icon>text_snippet</mat-icon> CSV
+          </button>
 
-        <mat-paginator
-          [length]="historyItemsCount"
-          [pageIndex]="currentPage"
-          [pageSize]="itemsPerPage"
-          [pageSizeOptions]="pageSizeOptions"
-          (page)="onPageChange($event)"
-          showFirstLastButtons
-        ></mat-paginator>
+          <div style="flex: 1;"></div>
+
+          <mat-paginator
+            [length]="historyItemsCount"
+            [pageIndex]="currentPage"
+            [pageSize]="itemsPerPage"
+            [pageSizeOptions]="pageSizeOptions"
+            (page)="onPageChange($event)"
+            showFirstLastButtons
+          ></mat-paginator>
+        </div>
 
         <table
           mat-table

--- a/src/app/datasets/dataset-lifecycle/dataset-lifecycle.component.scss
+++ b/src/app/datasets/dataset-lifecycle/dataset-lifecycle.component.scss
@@ -22,6 +22,10 @@ mat-card {
     }
   }
 
+  .download-button {
+    margin-bottom: 0.5em;
+  }
+
   .history-header {
     background-color: mat-color($accent, lighter);
   }

--- a/src/app/datasets/dataset-lifecycle/dataset-lifecycle.component.ts
+++ b/src/app/datasets/dataset-lifecycle/dataset-lifecycle.component.ts
@@ -115,7 +115,7 @@ export class DatasetLifecycleComponent implements OnInit, OnChanges {
     const url = window.URL.createObjectURL(blob);
 
     a.href = url;
-    a.download = this.dataset.pid + "_history.csv";
+    a.download = "history.csv";
     a.click();
     window.URL.revokeObjectURL(url);
     a.remove();


### PR DESCRIPTION
## Description

Add functionality to export dataset history to a CSV file.

## Motivation

Requested by ESS users.

## Changes:

* Add button for CSV export to dataset lifecycle component
* Add logic to export history to a CSV file
* Update formatting of dataset history for table

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

