### PR TITLE
Feature/exportable dois

### DIFF
--- a/src/app/publisheddata/publisheddata-dashboard/publisheddata-dashboard.component.html
+++ b/src/app/publisheddata/publisheddata-dashboard/publisheddata-dashboard.component.html
@@ -1,16 +1,33 @@
 <div fxLayout="row" fxLayout.lt-lt="column">
   <div fxFlex="14" fxFlex.lt-xl="10"></div>
   <div fxFlex="60" fxFlex.lt-xl="80">
+    <div style="float: right;">
+      <button
+        mat-icon-button
+        [disabled]="selectedDOIs.length === 0"
+        (click)="onShareClick()"
+      >
+        <mat-icon matTooltip="Copy selected DOI's to clipboard">
+          share
+        </mat-icon>
+      </button>
+    </div>
+
+    <div style="clear: both;"></div>
+
     <app-table
       [data]="publishedData$ | async"
       [columns]="columns"
       [paginate]="paginate"
+      [select]="select"
       [currentPage]="currentPage$ | async"
       [dataCount]="count$ | async"
       [dataPerPage]="itemsPerPage$ | async"
       (pageChange)="onPageChange($event)"
       (sortChange)="onSortChange($event)"
       (rowClick)="onRowClick($event)"
+      (selectAll)="onSelectAll($event)"
+      (selectOne)="onSelectOne($event)"
     ></app-table>
   </div>
   <div fxFlex="26" fxFlex.lt-xl="10"></div>

--- a/src/app/publisheddata/publisheddata-dashboard/publisheddata-dashboard.component.spec.ts
+++ b/src/app/publisheddata/publisheddata-dashboard/publisheddata-dashboard.component.spec.ts
@@ -141,13 +141,27 @@ describe("PublisheddataDashboardComponent", () => {
 
   describe("#onSelectAll()", () => {
     it("should add all DOI's to selectedDOIs if checked is true", () => {
+      const published = new PublishedData({
+        doi: "test",
+        creator: ["test"],
+        publisher: "test",
+        publicationYear: 2021,
+        title: "test",
+        abstract: "test",
+        dataDescription: "test",
+        resourceType: "test",
+        pidArray: [],
+      });
+
+      spyOn(component.publishedData$, "pipe").and.returnValue(of([published]));
+
       const event = {
         checked: true,
       } as MatCheckboxChange;
 
       component.onSelectAll(event);
 
-      expect(component.selectedDOIs.length).toEqual(0);
+      expect(component.selectedDOIs.length).toEqual(1);
     });
 
     it("should remove all DOI's from selectedDOIs if checked is false", () => {

--- a/src/app/publisheddata/publisheddata-dashboard/publisheddata-dashboard.component.spec.ts
+++ b/src/app/publisheddata/publisheddata-dashboard/publisheddata-dashboard.component.spec.ts
@@ -19,7 +19,7 @@ import {
   changePageAction,
   sortByColumnAction,
 } from "state-management/actions/published-data.actions";
-import { PublishedData, PublishedDataInterface } from "shared/sdk";
+import { PublishedData } from "shared/sdk";
 import { MatSnackBar } from "@angular/material/snack-bar";
 import { MatCheckboxChange } from "@angular/material/checkbox";
 import { of } from "rxjs";

--- a/src/app/publisheddata/publisheddata-dashboard/publisheddata-dashboard.component.spec.ts
+++ b/src/app/publisheddata/publisheddata-dashboard/publisheddata-dashboard.component.spec.ts
@@ -2,7 +2,7 @@ import {
   async,
   ComponentFixture,
   TestBed,
-  inject
+  inject,
 } from "@angular/core/testing";
 
 import { PublisheddataDashboardComponent } from "./publisheddata-dashboard.component";
@@ -10,16 +10,29 @@ import { MockStore } from "shared/MockStubs";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { StoreModule, Store } from "@ngrx/store";
 import { Router } from "@angular/router";
-import { PageChangeEvent } from "shared/modules/table/table.component";
-import { changePageAction } from "state-management/actions/published-data.actions";
-import { PublishedData } from "shared/sdk";
+import {
+  CheckboxEvent,
+  PageChangeEvent,
+  SortChangeEvent,
+} from "shared/modules/table/table.component";
+import {
+  changePageAction,
+  sortByColumnAction,
+} from "state-management/actions/published-data.actions";
+import { PublishedData, PublishedDataInterface } from "shared/sdk";
+import { MatSnackBar } from "@angular/material/snack-bar";
+import { MatCheckboxChange } from "@angular/material/checkbox";
+import { of } from "rxjs";
 
 describe("PublisheddataDashboardComponent", () => {
   let component: PublisheddataDashboardComponent;
   let fixture: ComponentFixture<PublisheddataDashboardComponent>;
 
   const router = {
-    navigateByUrl: jasmine.createSpy("navigateByUrl")
+    navigateByUrl: jasmine.createSpy("navigateByUrl"),
+  };
+  const snackBar = {
+    open: jasmine.createSpy("open"),
   };
   let store: MockStore;
   let dispatchSpy;
@@ -28,12 +41,15 @@ describe("PublisheddataDashboardComponent", () => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
       declarations: [PublisheddataDashboardComponent],
-      imports: [StoreModule.forRoot({})]
+      imports: [StoreModule.forRoot({})],
     });
     TestBed.overrideComponent(PublisheddataDashboardComponent, {
       set: {
-        providers: [{ provide: Router, useValue: router }]
-      }
+        providers: [
+          { provide: Router, useValue: router },
+          { provide: MatSnackBar, useValue: snackBar },
+        ],
+      },
     });
     TestBed.compileComponents();
   }));
@@ -56,6 +72,25 @@ describe("PublisheddataDashboardComponent", () => {
     expect(component).toBeTruthy();
   });
 
+  describe("#onShareClick()", () => {
+    it("should copy the selected DOI's to the users clipboard and open the snackbar", () => {
+      const commandSpy = spyOn(document, "execCommand");
+
+      component.onShareClick();
+
+      expect(commandSpy).toHaveBeenCalledTimes(1);
+      expect(commandSpy).toHaveBeenCalledWith("copy");
+      expect(snackBar.open).toHaveBeenCalledTimes(1);
+      expect(
+        snackBar.open
+      ).toHaveBeenCalledWith(
+        "The selected DOI's have been copied to your clipboard",
+        "",
+        { duration: 5000 }
+      );
+    });
+  });
+
   describe("#onPageChange()", () => {
     it("should dispatch a changePageAction action", () => {
       dispatchSpy = spyOn(store, "dispatch");
@@ -63,13 +98,30 @@ describe("PublisheddataDashboardComponent", () => {
       const event: PageChangeEvent = {
         pageIndex: 0,
         pageSize: 25,
-        length: 25
+        length: 25,
       };
       component.onPageChange(event);
 
       expect(dispatchSpy).toHaveBeenCalledTimes(1);
       expect(dispatchSpy).toHaveBeenCalledWith(
         changePageAction({ page: event.pageIndex, limit: event.pageSize })
+      );
+    });
+  });
+
+  describe("#onSortChange()", () => {
+    it("should dispatch a sortByColumnAction", () => {
+      dispatchSpy = spyOn(store, "dispatch");
+
+      const event: SortChangeEvent = {
+        active: "title",
+        direction: "asc",
+      };
+      component.onSortChange(event);
+
+      expect(dispatchSpy).toHaveBeenCalledTimes(1);
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        sortByColumnAction({ column: event.active, direction: event.direction })
       );
     });
   });
@@ -84,6 +136,61 @@ describe("PublisheddataDashboardComponent", () => {
       expect(router.navigateByUrl).toHaveBeenCalledWith(
         "/publishedDatasets/" + id
       );
+    });
+  });
+
+  describe("#onSelectAll()", () => {
+    it("should add all DOI's to selectedDOIs if checked is true", () => {
+      const event = {
+        checked: true,
+      } as MatCheckboxChange;
+
+      component.onSelectAll(event);
+
+      expect(component.selectedDOIs.length).toEqual(0);
+    });
+
+    it("should remove all DOI's from selectedDOIs if checked is false", () => {
+      component.selectedDOIs.push(
+        component.doiBaseUrl + "test1",
+        component.doiBaseUrl + "test2"
+      );
+
+      const event = {
+        checked: false,
+      } as MatCheckboxChange;
+
+      component.onSelectAll(event);
+
+      expect(component.selectedDOIs.length).toEqual(0);
+    });
+  });
+
+  describe("#onSelectOne()", () => {
+    it("should add the selected DOI to selectedDOIs if checked is true", () => {
+      const checkboxEvent: CheckboxEvent = {
+        event: { checked: true } as MatCheckboxChange,
+        row: { doi: "test" },
+      };
+
+      component.onSelectOne(checkboxEvent);
+
+      expect(component.selectedDOIs).toContain(
+        component.doiBaseUrl + checkboxEvent.row.doi
+      );
+    });
+
+    it("should remove the deselected DOI from selectedDOIs if checked is false", () => {
+      const checkboxEvent: CheckboxEvent = {
+        event: { checked: false } as MatCheckboxChange,
+        row: { doi: "test" },
+      };
+
+      component.selectedDOIs.push(component.doiBaseUrl + checkboxEvent.row.doi);
+
+      component.onSelectOne(checkboxEvent);
+
+      expect(component.selectedDOIs.length).toEqual(0);
     });
   });
 });

--- a/src/app/publisheddata/publisheddata-dashboard/publisheddata-dashboard.component.ts
+++ b/src/app/publisheddata/publisheddata-dashboard/publisheddata-dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from "@angular/core";
+import { Component, OnInit, OnDestroy, Inject } from "@angular/core";
 import { Store, select } from "@ngrx/store";
 import { PublishedData } from "shared/sdk";
 import { Router } from "@angular/router";
@@ -18,9 +18,14 @@ import {
   PageChangeEvent,
   TableColumn,
   SortChangeEvent,
+  CheckboxEvent,
 } from "shared/modules/table/table.component";
 import { Subscription } from "rxjs";
 import * as rison from "rison";
+import { MatCheckboxChange } from "@angular/material/checkbox";
+import { DOCUMENT } from "@angular/common";
+import { MatSnackBar } from "@angular/material/snack-bar";
+import { take } from "rxjs/operators";
 
 @Component({
   selector: "app-publisheddata-dashboard",
@@ -39,11 +44,40 @@ export class PublisheddataDashboardComponent implements OnInit, OnDestroy {
     { name: "creator", icon: "face", sort: true, inList: true },
     // { name: "publicationYear", icon: "date_range", sort: true, inList: true },
     { name: "createdBy", icon: "account_circle", sort: true, inList: true },
-    { name: "createdAt", icon: "date_range", sort: true, inList: true, dateFormat: "yyyy-MM-dd HH:mm" },
+    {
+      name: "createdAt",
+      icon: "date_range",
+      sort: true,
+      inList: true,
+      dateFormat: "yyyy-MM-dd HH:mm",
+    },
   ];
   paginate = true;
+  select = true;
 
+  doiBaseUrl = "https://doi.org/";
+  selectedDOIs: string[] = [];
   filtersSubscription: Subscription;
+
+  onShareClick() {
+    const selectionBox = this.document.createElement("textarea");
+    selectionBox.style.position = "fixed";
+    selectionBox.style.left = "0";
+    selectionBox.style.top = "0";
+    selectionBox.style.opacity = "0";
+    selectionBox.value = this.selectedDOIs.join("\n");
+    this.document.body.appendChild(selectionBox);
+    selectionBox.focus();
+    selectionBox.select();
+    this.document.execCommand("copy");
+    this.document.body.removeChild(selectionBox);
+
+    this.snackBar.open(
+      "The selected DOI's have been copied to your clipboard",
+      "",
+      { duration: 5000 }
+    );
+  }
 
   onPageChange(event: PageChangeEvent) {
     this.store.dispatch(
@@ -61,7 +95,34 @@ export class PublisheddataDashboardComponent implements OnInit, OnDestroy {
     this.router.navigateByUrl("/publishedDatasets/" + id);
   }
 
-  constructor(private router: Router, private store: Store<PublishedData>) {}
+  onSelectAll(event: MatCheckboxChange) {
+    if (event.checked) {
+      this.publishedData$.pipe(take(1)).subscribe((published) => {
+        this.selectedDOIs = published.map(
+          ({ doi }) => this.doiBaseUrl + encodeURIComponent(doi)
+        );
+      });
+    } else {
+      this.selectedDOIs = [];
+    }
+  }
+
+  onSelectOne(checkboxEvent: CheckboxEvent) {
+    const { event, row } = checkboxEvent;
+    const doiUrl = this.doiBaseUrl + encodeURIComponent(row.doi);
+    if (event.checked) {
+      this.selectedDOIs.push(doiUrl);
+    } else {
+      this.selectedDOIs.splice(this.selectedDOIs.indexOf(doiUrl), 1);
+    }
+  }
+
+  constructor(
+    @Inject(DOCUMENT) private document: Document,
+    private router: Router,
+    private snackBar: MatSnackBar,
+    private store: Store<PublishedData>
+  ) {}
 
   ngOnInit() {
     this.store.dispatch(fetchAllPublishedDataAction());

--- a/src/app/publisheddata/publisheddata.module.ts
+++ b/src/app/publisheddata/publisheddata.module.ts
@@ -21,6 +21,7 @@ import { MatChipsModule } from "@angular/material/chips";
 import { MatOptionModule } from "@angular/material/core";
 import { MatInputModule } from "@angular/material/input";
 import { MatSelectModule } from "@angular/material/select";
+import { MatTooltipModule } from "@angular/material/tooltip";
 
 @NgModule({
   declarations: [
@@ -38,6 +39,7 @@ import { MatSelectModule } from "@angular/material/select";
     MatInputModule,
     MatIconModule,
     MatSelectModule,
+    MatTooltipModule,
     NgxJsonViewerModule,
     SharedCatanieModule,
     StoreModule.forFeature("publishedData", publishedDataReducer),


### PR DESCRIPTION
## Description

Add functionality to Published Data view that allows users to share DOI links of the format "https://doi.org/[...]".

## Motivation

Requested by users.

## Changes:

* Add selection column to Published Data table
* Add share button that copies the selected DOI's to the user's clipboard

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

