### PR TITLE
Feature/dataset detail regrouping

### DIFF
--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -2,6 +2,244 @@
   <div fxFlex="80%">
     <mat-card>
       <mat-card-header class="about-header">
+        <div mat-card-avatar class="section-icon">
+          <mat-icon> description </mat-icon>
+        </div>
+        General Information
+      </mat-card-header>
+
+      <table class="about-table">
+        <tr *ngIf="dataset.datasetName as value">
+          <th>Name</th>
+          <td>{{ value }}</td>
+        </tr>
+        <tr *ngIf="dataset.description as value">
+          <th>Description</th>
+          <td><span [innerHTML]="value | linky"></span></td>
+        </tr>
+        <tr>
+          <th>PID</th>
+          <td>{{ dataset.pid }}</td>
+        </tr>
+        <tr *ngIf="dataset.type as value">
+          <th>Type</th>
+          <td>{{ value }}</td>
+        </tr>
+        <tr *ngIf="dataset.creationTime as value">
+          <th>Creation Time</th>
+          <td>{{ value | date: "yyyy-MM-dd HH:mm" }}</td>
+        </tr>
+        <tr class="keywords-row">
+          <th>Keywords</th>
+          <td *ngIf="!editEnabled">
+            <mat-chip-list #keywordChips>
+              <mat-chip
+                *ngFor="let keyword of dataset.keywords"
+                [removable]="true"
+                (removed)="onRemoveKeyword(keyword)"
+                (click)="onClickKeyword(keyword)"
+              >
+                {{ keyword }}
+                <mat-icon matChipRemove>cancel</mat-icon>
+              </mat-chip>
+              <mat-chip class="add-keyword-chip" (click)="editEnabled = true">
+                Add Keyword <mat-icon>add</mat-icon>
+              </mat-chip>
+            </mat-chip-list>
+          </td>
+          <td *ngIf="editEnabled">
+            <mat-form-field>
+              <mat-chip-list #keywordChips>
+                <mat-chip
+                  *ngFor="let keyword of dataset.keywords"
+                  [removable]="true"
+                  (removed)="onRemoveKeyword(keyword)"
+                  (click)="onClickKeyword(keyword)"
+                >
+                  {{ keyword }}
+                  <mat-icon matChipRemove>cancel</mat-icon>
+                </mat-chip>
+                <input
+                  id="keywordInput"
+                  [matChipInputFor]="keywordChips"
+                  [matChipInputSeparatorKeyCodes]="separatorKeyCodes"
+                  [matChipInputAddOnBlur]="true"
+                  (matChipInputTokenEnd)="onAddKeyword($event)"
+                />
+              </mat-chip-list>
+            </mat-form-field>
+            <button
+              mat-raised-button
+              class="done-edit-button"
+              color="accent"
+              (click)="editEnabled = false"
+            >
+              Done
+            </button>
+          </td>
+        </tr>
+      </table>
+    </mat-card>
+
+    <mat-card>
+      <mat-card-header class="structural-header">
+        <div mat-card-avatar class="section-icon">
+          <mat-icon> person </mat-icon>
+        </div>
+        Creator Information
+      </mat-card-header>
+
+      <table>
+        <tr *ngIf="dataset.owner as value">
+          <th>Owner</th>
+          <td>{{ value }}</td>
+        </tr>
+        <tr *ngIf="dataset.principalInvestigator as value">
+          <th>Principal Investigator</th>
+          <td><span [innerHTML]="value | linky"></span></td>
+        </tr>
+        <tr *ngIf="dataset.investigator as value">
+          <th>Investigator</th>
+          <td>{{ value }}</td>
+        </tr>
+        <tr *ngIf="dataset.orcidOfOwner as value">
+          <th>Orcid</th>
+          <td><span [innerHTML]="value | linky"></span></td>
+        </tr>
+        <tr *ngIf="dataset.contactEmail as value">
+          <th>Contact Email</th>
+          <td><span [innerHTML]="value | linky"></span></td>
+        </tr>
+        <tr *ngIf="dataset.ownerGroup as value">
+          <th>Owner Group</th>
+          <td>{{ value }}</td>
+        </tr>
+        <tr *ngIf="dataset.accessGroups as value">
+          <th>Access Groups</th>
+          <td>{{ value }}</td>
+        </tr>
+      </table>
+    </mat-card>
+
+    <mat-card>
+      <mat-card-header class="admin-header">
+        <div mat-card-avatar class="section-icon">
+          <mat-icon> folder </mat-icon>
+        </div>
+        File Information
+      </mat-card-header>
+
+      <table>
+        <tr *ngIf="dataset.sourceFolder as value">
+          <th>Source Folder</th>
+          <td>{{ value }}</td>
+        </tr>
+        <tr *ngIf="dataset.size as value">
+          <th>Size</th>
+          <td>{{ value | filesize }}</td>
+        </tr>
+        <tr *ngIf="dataset.dataFormat as value">
+          <th>Data Format</th>
+          <td>{{ value }}</td>
+        </tr>
+      </table>
+    </mat-card>
+
+    <mat-card>
+      <mat-card-header class="derived-header">
+        <div mat-card-avatar class="section-icon">
+          <mat-icon> library_books </mat-icon>
+        </div>
+        Related Documents
+      </mat-card-header>
+
+      <table>
+        <tr *ngIf="dataset.proposalId && proposal">
+          <th>Proposal</th>
+          <td (click)="onClickProposal(proposal.proposalId)">
+            <a>{{ proposal.title }}</a>
+          </td>
+        </tr>
+        <tr *ngIf="dataset.sampleId && sample">
+          <th>Sample</th>
+          <td>
+            <a (click)="onClickSample(sample.sampleId)">{{
+              sample.description
+            }}</a>
+            <span
+              class="sample-edit"
+              (click)="openSampleEditDialog()"
+              *ngIf="appConfig.editDatasetSampleEnabled && isPI"
+            >
+              <mat-icon>edit</mat-icon>
+            </span>
+          </td>
+        </tr>
+        <tr *ngIf="dataset.creationLocation as value">
+          <th>Creation Location</th>
+          <td>{{ value }}</td>
+        </tr>
+        <tr *ngIf="dataset.techniques.length > 0">
+          <th>Techniques</th>
+          <td>
+            <div *ngFor="let technique of dataset.techniques">
+              <span>
+                {{ technique.name }}
+              </span>
+              <span
+                *ngIf="
+                  dataset.techniques.indexOf(technique) <
+                  dataset.techniques.length - 1
+                "
+                >,
+              </span>
+            </div>
+          </td>
+        </tr>
+        <tr *ngIf="dataset.inputDatasets as value">
+          <th>Input Datasets</th>
+          <td>
+            <div *ngFor="let datasetPid of value">
+              <span>
+                <a [routerLink]="['/datasets/', datasetPid]">
+                  {{ datasetPid }}
+                </a>
+              </span>
+              <span *ngIf="value.indexOf(datasetPid) < value.length - 1"
+                >,
+              </span>
+            </div>
+          </td>
+        </tr>
+      </table>
+    </mat-card>
+
+    <mat-card *ngIf="dataset.type === 'derived'">
+      <mat-card-header class="new-header">
+        <div mat-card-avatar class="section-icon">
+          <mat-icon> analytics </mat-icon>
+        </div>
+        Derived Data
+      </mat-card-header>
+
+      <table>
+        <tr *ngIf="dataset.usedSoftware as value">
+          <th>Software Used</th>
+          <td>{{ value }}</td>
+        </tr>
+        <tr *ngIf="dataset.jobParameters as value">
+          <th>Job Parameters</th>
+          <td>{{ value | json }}</td>
+        </tr>
+        <tr *ngIf="dataset.jobLogData as value">
+          <th>Job Log Data</th>
+          <td>{{ value }}</td>
+        </tr>
+      </table>
+    </mat-card>
+
+    <!-- <mat-card>
+      <mat-card-header class="about-header">
         About the data
       </mat-card-header>
 
@@ -76,9 +314,9 @@
           </td>
         </tr>
       </table>
-    </mat-card>
+    </mat-card> -->
 
-    <mat-card>
+    <!-- <mat-card>
       <mat-card-header class="structural-header">
         Structural information
       </mat-card-header>
@@ -122,9 +360,9 @@
           <td><span [innerHTML]="value | linky"></span></td>
         </tr>
       </table>
-    </mat-card>
+    </mat-card> -->
 
-    <mat-card>
+    <!-- <mat-card>
       <mat-card-header class="admin-header">
         Administrative information
       </mat-card-header>
@@ -155,9 +393,9 @@
           <td><span [innerHTML]="value | linky"></span></td>
         </tr>
       </table>
-    </mat-card>
+    </mat-card> -->
 
-    <mat-card *ngIf="dataset.investigator">
+    <!-- <mat-card *ngIf="dataset.investigator">
       <mat-card-header class="derived-header">
         Derived Data
       </mat-card-header>
@@ -195,10 +433,13 @@
           <td>{{ value }}</td>
         </tr>
       </table>
-    </mat-card>
+    </mat-card> -->
 
     <mat-card>
       <mat-card-header class="scientific-header">
+        <div mat-card-avatar class="section-icon">
+          <mat-icon> science </mat-icon>
+        </div>
         Scientific Metadata
       </mat-card-header>
 

--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -1,14 +1,14 @@
 <div fxLayout="row" fxLayout.xs="column" *ngIf="dataset">
   <div fxFlex="80%">
     <mat-card>
-      <mat-card-header class="about-header">
+      <mat-card-header class="general-header">
         <div mat-card-avatar class="section-icon">
           <mat-icon> description </mat-icon>
         </div>
         General Information
       </mat-card-header>
 
-      <table class="about-table">
+      <table>
         <tr *ngIf="dataset.datasetName as value">
           <th>Name</th>
           <td>{{ value }}</td>
@@ -82,7 +82,7 @@
     </mat-card>
 
     <mat-card>
-      <mat-card-header class="structural-header">
+      <mat-card-header class="creator-header">
         <div mat-card-avatar class="section-icon">
           <mat-icon> person </mat-icon>
         </div>
@@ -122,7 +122,7 @@
     </mat-card>
 
     <mat-card>
-      <mat-card-header class="admin-header">
+      <mat-card-header class="file-header">
         <div mat-card-avatar class="section-icon">
           <mat-icon> folder </mat-icon>
         </div>
@@ -146,7 +146,7 @@
     </mat-card>
 
     <mat-card>
-      <mat-card-header class="derived-header">
+      <mat-card-header class="related-header">
         <div mat-card-avatar class="section-icon">
           <mat-icon> library_books </mat-icon>
         </div>
@@ -215,7 +215,7 @@
     </mat-card>
 
     <mat-card *ngIf="dataset.type === 'derived'">
-      <mat-card-header class="new-header">
+      <mat-card-header class="derived-header">
         <div mat-card-avatar class="section-icon">
           <mat-icon> analytics </mat-icon>
         </div>
@@ -237,203 +237,6 @@
         </tr>
       </table>
     </mat-card>
-
-    <!-- <mat-card>
-      <mat-card-header class="about-header">
-        About the data
-      </mat-card-header>
-
-      <table class="about-table">
-        <tr *ngIf="dataset.datasetName as value">
-          <th><mat-icon> fingerprint </mat-icon> Name</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="dataset.description as value">
-          <th><mat-icon> description </mat-icon> Description</th>
-          <td><span [innerHTML]="value | linky"></span></td>
-        </tr>
-        <tr *ngIf="dataset.owner as value">
-          <th><mat-icon> person </mat-icon> Owner</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr>
-          <th><mat-icon> perm_contact_calendar </mat-icon> PID</th>
-          <td>{{ dataset.pid }}</td>
-        </tr>
-        <tr *ngIf="dataset.sourceFolder as value">
-          <th><mat-icon> folder </mat-icon> Source Folder</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr class="keywords-row">
-          <th><mat-icon> vpn_key </mat-icon> Keywords</th>
-          <td *ngIf="!editEnabled">
-            <mat-chip-list #keywordChips>
-              <mat-chip
-                *ngFor="let keyword of dataset.keywords"
-                [removable]="true"
-                (removed)="onRemoveKeyword(keyword)"
-                (click)="onClickKeyword(keyword)"
-              >
-                {{ keyword }}
-                <mat-icon matChipRemove>cancel</mat-icon>
-              </mat-chip>
-              <mat-chip class="add-keyword-chip" (click)="editEnabled = true">
-                Add Keyword <mat-icon>add</mat-icon>
-              </mat-chip>
-            </mat-chip-list>
-          </td>
-          <td *ngIf="editEnabled">
-            <mat-form-field>
-              <mat-chip-list #keywordChips>
-                <mat-chip
-                  *ngFor="let keyword of dataset.keywords"
-                  [removable]="true"
-                  (removed)="onRemoveKeyword(keyword)"
-                  (click)="onClickKeyword(keyword)"
-                >
-                  {{ keyword }}
-                  <mat-icon matChipRemove>cancel</mat-icon>
-                </mat-chip>
-                <input
-                  id="keywordInput"
-                  [matChipInputFor]="keywordChips"
-                  [matChipInputSeparatorKeyCodes]="separatorKeyCodes"
-                  [matChipInputAddOnBlur]="true"
-                  (matChipInputTokenEnd)="onAddKeyword($event)"
-                />
-              </mat-chip-list>
-            </mat-form-field>
-            <button
-              mat-raised-button
-              class="done-edit-button"
-              color="accent"
-              (click)="editEnabled = false"
-            >
-              Done
-            </button>
-          </td>
-        </tr>
-      </table>
-    </mat-card> -->
-
-    <!-- <mat-card>
-      <mat-card-header class="structural-header">
-        Structural information
-      </mat-card-header>
-
-      <table>
-        <tr *ngIf="dataset.type as value">
-          <th><mat-icon> bubble_chart </mat-icon> Type</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="dataset.version as value">
-          <th><mat-icon> map </mat-icon> Version</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="dataset.proposalId && proposal">
-          <th><mat-icon> spa </mat-icon> Proposal</th>
-          <td (click)="onClickProposal(proposal.proposalId)">
-            <a>{{ proposal.title }}</a>
-          </td>
-        </tr>
-        <tr *ngIf="dataset.sampleId && sample">
-          <th><mat-icon> center_focus_weak </mat-icon> Sample</th>
-          <td>
-            <a (click)="onClickSample(sample.sampleId)">{{
-              sample.description
-            }}</a>
-            <span
-              class="sample-edit"
-              (click)="openSampleEditDialog()"
-              *ngIf="appConfig.editDatasetSampleEnabled && isPI"
-            >
-              <mat-icon>edit</mat-icon>
-            </span>
-          </td>
-        </tr>
-        <tr *ngIf="dataset.size as value">
-          <th><mat-icon> save </mat-icon> Size</th>
-          <td>{{ value | filesize }}</td>
-        </tr>
-        <tr *ngIf="dataset.orcidOfOwner as value">
-          <th><mat-icon> local_florist </mat-icon> Orcid</th>
-          <td><span [innerHTML]="value | linky"></span></td>
-        </tr>
-      </table>
-    </mat-card> -->
-
-    <!-- <mat-card>
-      <mat-card-header class="admin-header">
-        Administrative information
-      </mat-card-header>
-
-      <table>
-        <tr *ngIf="dataset.creationTime as value">
-          <th><mat-icon> calendar_today </mat-icon> Creation Time</th>
-          <td>{{ value | date: "yyyy-MM-dd HH:mm" }}</td>
-        </tr>
-        <tr *ngIf="dataset.principalInvestigator as value">
-          <th><mat-icon> brightness_5 </mat-icon> Principal Investigator</th>
-          <td><span [innerHTML]="value | linky"></span></td>
-        </tr>
-        <tr *ngIf="dataset.creationLocation as value">
-          <th><mat-icon> map </mat-icon> Creation Location</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="dataset.ownerGroup as value">
-          <th><mat-icon> group </mat-icon> Owner Group</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="dataset.accessGroups as value">
-          <th><mat-icon> supervisor_account </mat-icon> Access Groups</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="dataset.contactEmail as value">
-          <th><mat-icon> email </mat-icon> Contact Email</th>
-          <td><span [innerHTML]="value | linky"></span></td>
-        </tr>
-      </table>
-    </mat-card> -->
-
-    <!-- <mat-card *ngIf="dataset.investigator">
-      <mat-card-header class="derived-header">
-        Derived Data
-      </mat-card-header>
-
-      <table>
-        <tr *ngIf="dataset.investigator as value">
-          <th><mat-icon> school </mat-icon> Investigator</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="dataset.inputDatasets as value">
-          <th><mat-icon> input </mat-icon> Input Datasets</th>
-          <td>
-            <div *ngFor="let datasetPid of value">
-              <span>
-                <a [routerLink]="['/datasets/', datasetPid]">
-                  {{ datasetPid }}
-                </a>
-              </span>
-              <span *ngIf="value.indexOf(datasetPid) < value.length - 1"
-                >,
-              </span>
-            </div>
-          </td>
-        </tr>
-        <tr *ngIf="dataset.usedSoftware as value">
-          <th><mat-icon> screen_share</mat-icon> Software Used</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="dataset.jobParameters as value">
-          <th><mat-icon> settings </mat-icon> Job Parameters</th>
-          <td>{{ value | json }}</td>
-        </tr>
-        <tr *ngIf="dataset.jobLogData as value">
-          <th><mat-icon> ballot </mat-icon> Job Log Data</th>
-          <td>{{ value }}</td>
-        </tr>
-      </table>
-    </mat-card> -->
 
     <mat-card>
       <mat-card-header class="scientific-header">

--- a/src/app/datasets/dataset-detail/dataset-detail.component.scss
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.scss
@@ -19,8 +19,17 @@ mat-card {
     background-color: mat-color($forest, 400);
   }
 
+  .new-header {
+    background-color: mat-color($orange, 400);
+  }
+
   .scientific-header {
     background-color: mat-color($purple, 400);
+  }
+
+  .section-icon {
+    height: auto!important;
+    width: auto!important;
   }
 
   mat-icon {
@@ -56,7 +65,7 @@ mat-card {
 
   .about-table {
     th {
-      min-width: 10em;
+      min-width: 6em;
     }
 
     td {

--- a/src/app/datasets/dataset-detail/dataset-detail.component.scss
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.scss
@@ -3,23 +3,23 @@
 mat-card {
   margin: 1em;
 
-  .about-header {
+  .general-header {
     background-color: mat-color($primary, lighter);
   }
 
-  .structural-header {
+  .creator-header {
     background-color: mat-color($navy, 400);
   }
 
-  .admin-header {
+  .file-header {
     background-color: mat-color($accent, lighter);
   }
 
-  .derived-header {
+  .related-header {
     background-color: mat-color($forest, 400);
   }
 
-  .new-header {
+  .derived-header {
     background-color: mat-color($orange, 400);
   }
 
@@ -28,26 +28,24 @@ mat-card {
   }
 
   .section-icon {
-    height: auto!important;
-    width: auto!important;
-  }
+    height: auto !important;
+    width: auto !important;
 
-  mat-icon {
-    vertical-align: middle;
+    mat-icon {
+      vertical-align: middle;
+    }
   }
 
   table {
     th {
-      text-align: left;
+      min-width: 10em;
       padding-right: 0.5em;
+      text-align: left;
     }
 
     td {
+      width: 100%;
       padding: 0.5em;
-
-      a:hover {
-        cursor: pointer;
-      }
 
       .sample-edit {
         padding-left: 0.5em;
@@ -60,16 +58,6 @@ mat-card {
       .sample-edit:hover {
         cursor: pointer;
       }
-    }
-  }
-
-  .about-table {
-    th {
-      min-width: 6em;
-    }
-
-    td {
-      width: 100%;
     }
 
     .keywords-row {

--- a/src/index.html
+++ b/src/index.html
@@ -21,7 +21,7 @@
     <link rel="shortcut icon" href="favicon.ico">
 
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/css?family=Titillium+Web&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css?family=Titillium+Web:ital,wght@0,200;0,300;0,400;0,600;0,700;0,900;1,200;1,300;1,400;1,600;1,700&display=swap" rel="stylesheet" />
   </head>
   <body class="mat-typography">
     <app-root>Loading...</app-root>


### PR DESCRIPTION
## Description

Change field grouping in dataset details view.

## Motivation

Make grouping more logical.

## Changes:

* Regroup fields in dataset details view
* Remove field specific icons in favour of group icons
* Add additional font weights for Titillium Web

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

