### PR TITLE
Add OpenID connect Functionality

### DIFF
--- a/src/app/state-management/actions/user.actions.ts
+++ b/src/app/state-management/actions/user.actions.ts
@@ -2,6 +2,12 @@ import { createAction, props } from "@ngrx/store";
 import { User, AccessToken, UserIdentity, UserSetting } from "shared/sdk";
 import { Message, Settings } from "state-management/models";
 
+
+export const loginOIDCAction = createAction(
+  "[User] OIDC Login",
+  props <{accessToken: string; userId: string}>()
+)
+
 export const loginAction = createAction(
   "[User] Login",
   props<{ form: { username: string; password: string; rememberMe: boolean } }>()

--- a/src/app/state-management/effects/user.effects.ts
+++ b/src/app/state-management/effects/user.effects.ts
@@ -82,6 +82,28 @@ export class UserEffects {
     )
   );
 
+  oidcFetchUser$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(fromActions.loginOIDCAction),
+      switchMap(({ accessToken, userId }) => {
+        const token = new SDKToken({
+          id: accessToken,
+          userId: userId,
+        });
+        this.loopBackAuth.setToken(token);
+        return this.userApi.findById(userId).pipe(
+          switchMap((user: User) => [
+            fromActions.fetchUserCompleteAction(),
+            fromActions.loginCompleteAction({
+              user,
+              accountType: "external",
+            }),
+          ]),
+          catchError(() => of(fromActions.fetchUserFailedAction()))
+        );
+      })
+    )
+  );
   fetchUser$ = createEffect(() =>
     this.actions$.pipe(
       ofType(fromActions.fetchUserAction),

--- a/src/app/users/login/login.component.html
+++ b/src/app/users/login/login.component.html
@@ -3,11 +3,25 @@
     <div fxLayout="row" class="facility-logo">
       <div fxFlex="auto"></div>
       <div fxFlex="200px">
-        <img src="assets/images/site-logo.png" />
+        <img src="assets/images/esslogo.png" />
       </div>
       <div fxFlex="auto"></div>
     </div>
     <mat-card-content>
+
+        <button
+        mat-raised-button
+        class="login-button"
+        type="submit"
+        color="primary"
+        [ngClass]="{ loading: loading$ | async }"
+        (click) = "redirectOIDC()"
+      >
+       OIDC Log in
+      </button>
+    
+      
+      <!-- <a href="http://localhost:3000/auth/oidc"><button class="btn btn-success pull-right" >OIDC login</button></a> -->
       <form [formGroup]="loginForm" (ngSubmit)="onLogin()">
         <mat-form-field hintLabel="{{appConfig.facility}} account username">
           <mat-label> <b> Username</b> </mat-label>


### PR DESCRIPTION
## Description
Add ability authenticate through OIDC.

## Motivation
Use Case: my facility does not have users stored in LDAP/AD. We have a user system that stores information in a custom database, and allows users to authenticate through ORCID. So, to prevent users from having to create new accounts in Scicat, we would want ORCID authentication. ORCID exposes OIDC. 

To date, catanie can authenticate with two catemel/loopback/passport providers: local and ldap. Catanie communicates with catamel through loopback SDK methods. A user enters username and password in catanie, this gets sent to loopback, which responds with and access_token and user_id.

Passport has several other authentication strategies available, including OIDC. OIDC authentication differs from LDAP in several ways. One fundamental different is the the resource app (catamel/catanie) does not ever deal with the users authentication information. Instead, it redirects the user to the OIDC provider's website. On successful authentication, the OIDC provider redirects the user's browser back to the service provider's site. This means that catanie must interact in a slightly different way than it does for existing authentication.

## Changes:
* login-component.html - added a new button currently called "OIDC Login" that starts the authentication process
* login-component.ts 
   *  inject `Document` into the constructor, used to redirect the user
   * add method `redirectOIDC()` to redirect user to OIDC login
   * changed `ngOnInit()` adding a subscription to listen for  the part  of the url path that tells us an access_token is available
* user.actions.ts - adds `loginOIDCAction` 
* user.effects.tx - add new `oidcFetchUser$` to observe the `loginOIDCAction` and construct a new `SDKToken` object and complete the login.
Here is a high level view of how the flow works:
![image](https://user-images.githubusercontent.com/40469975/113350473-5fad5980-92ee-11eb-9d92-90a4ef1d945c.png)


## What's not there yet?
I am submitting this incomplete to get people's eyes on it and tell me if this is sensible. Things that need to be done for sure:
- [ ] Handle login failure
- [ ] Get accessGroup information from the UserIdnetity collection
- [ ] Make this configurable...I can imagine some sites want only OIDC, only LDAP and maybe a combination of the two? Right now, both options are placed on the login form.

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

