### PR TITLE
Add Format number pipe

### DIFF
--- a/src/app/shared/modules/scientific-metadata-tree/base-classes/metadata-input-base.spec.ts
+++ b/src/app/shared/modules/scientific-metadata-tree/base-classes/metadata-input-base.spec.ts
@@ -4,6 +4,7 @@ import { MatAutocompleteModule } from "@angular/material/autocomplete";
 import { Type } from "../base-classes/metadata-input-base";
 import { FlatNodeEdit } from "../tree-edit/tree-edit.component";
 import { MetadataInputComponent} from "../metadata-input/metadata-input.component";
+import { FormatNumberPipe } from "shared/pipes/format-number.pipe";
 
 describe("MetadataInputBase", () => {
   let component: MetadataInputComponent;
@@ -15,7 +16,7 @@ describe("MetadataInputBase", () => {
       imports: [
         MatAutocompleteModule,
       ],
-      providers: [FormBuilder]
+      providers: [FormBuilder, FormatNumberPipe]
     })
       .compileComponents();
   }));

--- a/src/app/shared/modules/scientific-metadata-tree/base-classes/tree-base.ts
+++ b/src/app/shared/modules/scientific-metadata-tree/base-classes/tree-base.ts
@@ -2,6 +2,8 @@ import { FlatTreeControl } from "@angular/cdk/tree";
 import { DatePipe } from "@angular/common";
 import { Component } from "@angular/core";
 import { MatTreeFlatDataSource, MatTreeFlattener } from "@angular/material/tree";
+import { FormatNumberPipe } from "shared/pipes/format-number.pipe";
+import { PrettyUnitPipe } from "shared/pipes/pretty-unit.pipe";
 import { UnitsService } from "shared/services/units.service";
 
 export class TreeNode {
@@ -32,9 +34,13 @@ export class TreeBaseComponent {
   dataTree: TreeNode[];
   _filterText = "";
   datePipe: DatePipe;
+  formatNumberPipe: FormatNumberPipe;
+  prettyUnitPipe: PrettyUnitPipe;
   unitsService: UnitsService;
   constructor() {
     this.unitsService = new UnitsService();
+    this.prettyUnitPipe = new PrettyUnitPipe(this.unitsService);
+    this.formatNumberPipe = new FormatNumberPipe();
   }
   buildDataTree(obj: { [key: string]: any }, level: number): TreeNode[] {
     return Object.keys(obj).reduce<TreeNode[]>((accumulator, key) => {
@@ -196,7 +202,7 @@ export class TreeBaseComponent {
       return "\"\"";
     }
     if (node.unit) {
-      return `${node.value} (${this.unitsService.getSymbol(node.unit)})`;
+      return `${this.formatNumberPipe.transform(node.value)} (${this.prettyUnitPipe.transform(node.unit)})`;
     }
     if (typeof node.value === "string" && !isNaN(Date.parse(node.value))) {
       return this.datePipe.transform(node.value, "yyyy-MM-dd, HH:mm:ss zzzz");

--- a/src/app/shared/modules/scientific-metadata-tree/metadata-input/metadata-input.component.spec.ts
+++ b/src/app/shared/modules/scientific-metadata-tree/metadata-input/metadata-input.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
 import { FormBuilder } from "@angular/forms";
 import { MatAutocompleteModule } from "@angular/material/autocomplete";
+import { FormatNumberPipe } from "shared/pipes/format-number.pipe";
 import { Type } from "../base-classes/metadata-input-base";
 import { FlatNodeEdit } from "../tree-edit/tree-edit.component";
 
@@ -16,7 +17,7 @@ describe("MetadataInputComponent", () => {
       imports: [
         MatAutocompleteModule,
       ],
-      providers: [FormBuilder]
+      providers: [FormBuilder, FormatNumberPipe]
     })
       .compileComponents();
   }));

--- a/src/app/shared/modules/scientific-metadata-tree/metadata-input/metadata-input.component.ts
+++ b/src/app/shared/modules/scientific-metadata-tree/metadata-input/metadata-input.component.ts
@@ -3,6 +3,7 @@ import { FormBuilder, FormControl, Validators } from "@angular/forms";
 import { Subscription } from "rxjs";
 import { FlatNodeEdit } from "../tree-edit/tree-edit.component";
 import { MetadataInputBase, Type } from "../base-classes/metadata-input-base";
+import { FormatNumberPipe } from "shared/pipes/format-number.pipe";
 
 export interface InputData {
   type: string;
@@ -28,7 +29,7 @@ export class MetadataInputComponent extends MetadataInputBase implements OnInit 
   @Output() cancel = new EventEmitter();
   @Output() changed = new EventEmitter();
 
-  constructor(private formBuilder: FormBuilder) {
+  constructor(private formBuilder: FormBuilder, private formatNumberPipe: FormatNumberPipe) {
     super();
   }
   ngOnInit() {
@@ -68,7 +69,8 @@ export class MetadataInputComponent extends MetadataInputBase implements OnInit 
       if (node.unit) {
         this.metadataForm.get("type").setValue(Type.quantity);
         this.metadataForm.get("key").setValue(node.key);
-        this.metadataForm.get("value").setValue(node.value || "");
+        const formattedValue = this.formatNumberPipe.transform(node.value);
+        this.metadataForm.get("value").setValue(formattedValue || "");
         this.metadataForm.get("unit").setValue(node.unit);
       } else if (typeof node.value === Type.number) {
         this.metadataForm.get("type").setValue(Type.number);

--- a/src/app/shared/modules/scientific-metadata-tree/scientific-metadata-tree.modules.ts
+++ b/src/app/shared/modules/scientific-metadata-tree/scientific-metadata-tree.modules.ts
@@ -22,6 +22,8 @@ import { MetadataInputModalComponent } from "./metadata-input-modal/metadata-inp
 import {MatDialogModule} from "@angular/material/dialog";
 import { MatMenuModule } from "@angular/material/menu";
 import { MatSnackBarModule } from "@angular/material/snack-bar";
+import { PrettyUnitPipe } from "shared/pipes/pretty-unit.pipe";
+import { FormatNumberPipe } from "shared/pipes/format-number.pipe";
 @NgModule({
   declarations: [TreeEditComponent, TreeViewComponent, MetadataInputComponent, MetadataInputModalComponent],
   imports: [
@@ -49,6 +51,6 @@ import { MatSnackBarModule } from "@angular/material/snack-bar";
     MatSnackBarModule
   ],
   exports: [TreeEditComponent, TreeViewComponent],
-  providers:[DatePipe]
+  providers:[DatePipe, PrettyUnitPipe, FormatNumberPipe]
 })
 export class ScientificMetadataTreeModule {}

--- a/src/app/shared/modules/scientific-metadata-tree/tree-view/tree-view.component.spec.ts
+++ b/src/app/shared/modules/scientific-metadata-tree/tree-view/tree-view.component.spec.ts
@@ -1,5 +1,7 @@
 import { DatePipe } from "@angular/common";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { FormatNumberPipe } from "shared/pipes/format-number.pipe";
+import { PrettyUnitPipe } from "shared/pipes/pretty-unit.pipe";
 
 import { TreeViewComponent } from "./tree-view.component";
 
@@ -12,6 +14,8 @@ describe("TreeViewComponent", () => {
       declarations: [ TreeViewComponent ],
       providers:[
         DatePipe,
+        PrettyUnitPipe,
+        FormatNumberPipe
       ]
     })
     .compileComponents();

--- a/src/app/shared/pipes/format-number.pipe.spect.ts
+++ b/src/app/shared/pipes/format-number.pipe.spect.ts
@@ -1,0 +1,46 @@
+import { FormatNumberPipe } from "./format-number.pipe";
+
+describe("FormatNumberPipe", () => {
+  it("create an instance", () => {
+    const pipe = new FormatNumberPipe();
+    expect(pipe).toBeTruthy();
+  });
+
+  it("returns exponential number when number >= 1e5 ", () => {
+    const pipe = new FormatNumberPipe();
+    const nbr = 100000;
+    const formatted = pipe.transform(nbr);
+    expect(formatted.toString()).toEqual("1e+5");
+  });
+
+  it("returns exponential number when number <= 1e-5", () => {
+    const pipe = new FormatNumberPipe();
+    const nbr = 0.00001;
+    const formatted = pipe.transform(nbr);
+    expect(formatted.toString()).toEqual("1e-5");
+  });
+  it("returns number when 1e-5 <= number <= 1e5", () => {
+    const pipe = new FormatNumberPipe();
+    const nbr = 0.0001;
+    const formatted = pipe.transform(nbr);
+    expect(formatted).toEqual(nbr);
+  });
+  it("returns null when number is null", () => {
+    const pipe = new FormatNumberPipe();
+    const nbr = null;
+    const formatted = pipe.transform(nbr);
+    expect(formatted).toBeNull();
+  });
+  it("returns undefined when number is undefined", () => {
+    const pipe = new FormatNumberPipe();
+    const nbr = undefined;
+    const formatted = pipe.transform(nbr);
+    expect(formatted).toBeUndefined();
+  });
+  it("returns string when number is a string", () => {
+    const pipe = new FormatNumberPipe();
+    const nbr = "test";
+    const formatted = pipe.transform(nbr);
+    expect(formatted).toEqual("test");
+  });
+});

--- a/src/app/shared/pipes/format-number.pipe.ts
+++ b/src/app/shared/pipes/format-number.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from "@angular/core";
+@Pipe({
+  name: "formatNumber"
+})
+export class FormatNumberPipe implements PipeTransform {
+  transform(value: any){
+    if(typeof value === "number" && (value >= 1e5 || value <= 1e-5)){
+      return value.toExponential();
+    }
+    return value;
+  }
+}

--- a/src/app/shared/pipes/pipes.module.ts
+++ b/src/app/shared/pipes/pipes.module.ts
@@ -12,7 +12,7 @@ import { PrettyUnitPipe } from "./pretty-unit.pipe";
 import { DynamicPipe } from "./dynamicPipe.pipe";
 import { NewDynamicPipe } from "./newDynamicPipe.pipe";
 import { DescriptionTitlePipe } from "./description-title.pipe";
-
+import { FormatNumberPipe } from "./format-number.pipe";
 @NgModule({
   declarations: [
     FileSizePipe,
@@ -22,6 +22,7 @@ import { DescriptionTitlePipe } from "./description-title.pipe";
     PrettyUnitPipe,
     ReplaceUnderscorePipe,
     StripProposalPrefixPipe,
+    FormatNumberPipe,
     ThumbnailPipe,
     TitleCasePipe,
     DynamicPipe,
@@ -37,6 +38,7 @@ import { DescriptionTitlePipe } from "./description-title.pipe";
     PrettyUnitPipe,
     ReplaceUnderscorePipe,
     StripProposalPrefixPipe,
+    FormatNumberPipe,
     ThumbnailPipe,
     TitleCasePipe,
     DynamicPipe,

--- a/src/app/shared/services/units.service.ts
+++ b/src/app/shared/services/units.service.ts
@@ -34,7 +34,8 @@ export class UnitsService {
       "minutes",
       "seconds"
     ],
-    volume: ["cm^3", "dm^3", "m^3", "mm^3"]
+    volume: ["cm^3", "dm^3", "m^3", "mm^3"],
+    flux: ["s^-1"]
   };
 
   private SYMBOLS = {
@@ -68,7 +69,8 @@ export class UnitsService {
     "cm^3": "cm\u00B3",
     "dm^3": "dm\u00B3",
     "m^3": "m\u00B3",
-    "mm^3": "mm\u00B3"
+    "mm^3": "mm\u00B3",
+    "s^-1":"s\u207b\u00B9"
   };
 
   private getKind(variable: string): string {


### PR DESCRIPTION
## Description
Added a new pipe to format large or very small number to exponential number. 
## Motivation
Large or very small number looks better in exponential format than in native format. For example 28e5 vs 2800000 or 28e-5 vs 0.00028
* Items added
- FormatNumberPipe
- new unit and unit symbol s^-1
## Tests included/Docs Updated?
- [x] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

