### PR TITLE
Add 3s timeout to ad login

### DIFF
--- a/src/app/users/adauth.service.ts
+++ b/src/app/users/adauth.service.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpResponse, HttpHeaders } from "@angular/common/http";
 import { LoopBackConfig } from "shared/sdk/lb.config";
 import { Observable } from "rxjs";
 import { APP_CONFIG, AppConfig } from "../app-config.module";
+import { timeout } from "rxjs/operators";
 
 /**
  * Handles log in requests for AD and Functional users
@@ -41,6 +42,6 @@ export class ADAuthService {
     const headers = new HttpHeaders();
     const url = LoopBackConfig.getPath() + this.config.externalAuthEndpoint;
     headers.append("Content-Type", "application/x-www-form-urlencoded");
-    return this.http.post<AccessToken>(url, creds, { observe: "response" });
+    return this.http.post<AccessToken>(url, creds, { observe: "response" }).pipe(timeout(3000));
   }
 }


### PR DESCRIPTION
## Description

Add rxjs timeout operator to msad login to reduce timeout.

## Motivation

See #579

## Fixes:

* Fixes #579

## Changes:

* Add pipe with timeout operator set to 3 s to http request in ADAuthService

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

