### PR TITLE
Add connection error message

### DIFF
--- a/src/app/state-management/actions/user.actions.spec.ts
+++ b/src/app/state-management/actions/user.actions.spec.ts
@@ -89,7 +89,6 @@ describe("User Actions", () => {
   });
 
   describe("funcLoginAction", () => {
-    const error = new HttpErrorResponse({});
     it("should create an action", () => {
       const username = "test";
       const password = "test";

--- a/src/app/state-management/actions/user.actions.spec.ts
+++ b/src/app/state-management/actions/user.actions.spec.ts
@@ -1,8 +1,10 @@
 import { Message, User, Settings, UserIdentity } from "../models";
 import * as fromActions from "./user.actions";
 import { AccessToken, UserSetting } from "shared/sdk";
+import { HttpErrorResponse } from "@angular/common/http";
 
-describe("User Aactions", () => {
+describe("User Actions", () => {
+  const error = new HttpErrorResponse({});
   describe("loginAction", () => {
     it("should create an action", () => {
       const form = { username: "", password: "", rememberMe: true };
@@ -29,9 +31,10 @@ describe("User Aactions", () => {
 
   describe("loginFailedAction", () => {
     it("should create an action", () => {
-      const action = fromActions.loginFailedAction();
+      const action = fromActions.loginFailedAction({ error });
       expect({ ...action }).toEqual({
-        type: "[User] Login Failed"
+        type: "[User] Login Failed",
+        error
       });
     });
   });
@@ -72,18 +75,21 @@ describe("User Aactions", () => {
       const action = fromActions.activeDirLoginFailedAction({
         username,
         password,
-        rememberMe
+        rememberMe,
+        error
       });
       expect({ ...action }).toEqual({
         type: "[User] Active Directory Login Failed",
         username,
         password,
-        rememberMe
+        rememberMe,
+        error
       });
     });
   });
 
   describe("funcLoginAction", () => {
+    const error = new HttpErrorResponse({});
     it("should create an action", () => {
       const username = "test";
       const password = "test";
@@ -91,13 +97,15 @@ describe("User Aactions", () => {
       const action = fromActions.funcLoginAction({
         username,
         password,
-        rememberMe
+        rememberMe,
+        error
       });
       expect({ ...action }).toEqual({
         type: "[User] Functional Login",
         username,
         password,
-        rememberMe
+        rememberMe,
+        error
       });
     });
   });
@@ -113,9 +121,10 @@ describe("User Aactions", () => {
 
   describe("funcLoginFailedAction", () => {
     it("should create an action", () => {
-      const action = fromActions.funcLoginFailedAction();
+      const action = fromActions.funcLoginFailedAction({ error });
       expect({ ...action }).toEqual({
-        type: "[User] Functional Login Failed"
+        type: "[User] Functional Login Failed",
+        error
       });
     });
   });
@@ -142,9 +151,10 @@ describe("User Aactions", () => {
 
   describe("fetchUserFailedAction", () => {
     it("should create an action", () => {
-      const action = fromActions.fetchUserFailedAction();
+      const action = fromActions.fetchUserFailedAction({ error });
       expect({ ...action }).toEqual({
-        type: "[User] Fetch User Failed"
+        type: "[User] Fetch User Failed",
+        error
       });
     });
   });

--- a/src/app/state-management/actions/user.actions.ts
+++ b/src/app/state-management/actions/user.actions.ts
@@ -1,3 +1,4 @@
+import { HttpErrorResponse } from "@angular/common/http";
 import { createAction, props } from "@ngrx/store";
 import { User, AccessToken, UserIdentity, UserSetting } from "shared/sdk";
 import { Message, Settings } from "state-management/models";
@@ -10,7 +11,10 @@ export const loginCompleteAction = createAction(
   "[User] Login Complete",
   props<{ user: User; accountType: string }>()
 );
-export const loginFailedAction = createAction("[User] Login Failed");
+export const loginFailedAction = createAction(
+  "[User] Login Failed",
+  props<{ error: HttpErrorResponse }>()
+);
 
 export const activeDirLoginAction = createAction(
   "[User] Active Directory Login",
@@ -21,18 +25,19 @@ export const activeDirLoginSuccessAction = createAction(
 );
 export const activeDirLoginFailedAction = createAction(
   "[User] Active Directory Login Failed",
-  props<{ username: string; password: string; rememberMe: boolean }>()
+  props<{ username: string; password: string; rememberMe: boolean; error: HttpErrorResponse }>()
 );
 
 export const funcLoginAction = createAction(
   "[User] Functional Login",
-  props<{ username: string; password: string; rememberMe: boolean }>()
+  props<{ username: string; password: string; rememberMe: boolean; error: HttpErrorResponse }>()
 );
 export const funcLoginSuccessAction = createAction(
   "[User] Functional Login Success"
 );
 export const funcLoginFailedAction = createAction(
-  "[User] Functional Login Failed"
+  "[User] Functional Login Failed",
+  props<{ error: HttpErrorResponse }>()
 );
 
 export const fetchUserAction = createAction(
@@ -42,7 +47,10 @@ export const fetchUserAction = createAction(
 export const fetchUserCompleteAction = createAction(
   "[User] Fetch User Complete"
 );
-export const fetchUserFailedAction = createAction("[User] Fetch User Failed");
+export const fetchUserFailedAction = createAction(
+  "[User] Fetch User Failed",
+  props<{ error: HttpErrorResponse }>()
+);
 
 export const fetchCurrentUserAction = createAction("[User] Fetch Current User");
 export const fetchCurrentUserCompleteAction = createAction(

--- a/src/app/state-management/effects/user.effects.spec.ts
+++ b/src/app/state-management/effects/user.effects.spec.ts
@@ -313,8 +313,7 @@ describe("UserEffects", () => {
         content: "Could not log in. Check your username and password.",
         duration: 5000,
       };
-      const error = new HttpErrorResponse({status:401})
-      const action = fromActions.loginFailedAction({error});
+      const action = fromActions.loginFailedAction({error:new HttpErrorResponse({status:401})});
       const outcome = fromActions.showMessageAction({ message });
 
       actions = hot("-a", { a: action });
@@ -328,8 +327,7 @@ describe("UserEffects", () => {
         content: "Unable to connect to the authentication service. Please try again later or contact website maintainer.",
         duration: 5000,
       };
-      const error = new HttpErrorResponse({status:500})
-      const action = fromActions.loginFailedAction({error});
+      const action = fromActions.loginFailedAction({error:new HttpErrorResponse({status:500})});
       const outcome = fromActions.showMessageAction({ message });
 
       actions = hot("-a", { a: action });

--- a/src/app/state-management/effects/user.effects.ts
+++ b/src/app/state-management/effects/user.effects.ts
@@ -155,7 +155,7 @@ export class UserEffects {
               type: MessageType.Error,
               duration: 5000,
             },
-          })
+          });
         }
         return fromActions.showMessageAction({
           message: {

--- a/src/app/state-management/reducers/user.reducer.spec.ts
+++ b/src/app/state-management/reducers/user.reducer.spec.ts
@@ -3,6 +3,7 @@ import { initialUserState } from "../state/user.store";
 import * as fromActions from "../actions/user.actions";
 import { User, MessageType, Message, Settings, UserIdentity } from "../models";
 import { AccessToken, UserSetting } from "shared/sdk";
+import { HttpErrorResponse } from "@angular/common/http";
 
 describe("UserReducer", () => {
   describe("on loginAction", () => {
@@ -36,7 +37,8 @@ describe("UserReducer", () => {
 
   describe("on loginFailedAction", () => {
     it("should set both isLoggingIn and isLoggedIn to false", () => {
-      const action = fromActions.loginFailedAction();
+      const error = new HttpErrorResponse({});
+      const action = fromActions.loginFailedAction(error);
       const state = userReducer(initialUserState, action);
 
       expect(state.isLoggingIn).toEqual(false);


### PR DESCRIPTION
## Description
See issue #470 
## Motivation
See issue #470 
## Fixes:
- Added an extra error message for failed login due to connection error in AD. This message could be useful when AD server is down or the URL to AD is wrong.
- Drawback : This message is only correct for external users. For functional account that don't require AD authentication the user should know that failed login has to do with invalid username/pwd and not connection error to AD.
## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

