### PR TITLE
Dataset detail

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -2,8 +2,8 @@
   "viewportWidth": 1280,
   "baseUrl": "http://localhost:4200",
   "lbBaseUrl": "http://localhost:3000/api/v3",
-  "username": "ingestor",
-  "password": "aman",
+  "username": "admin",
+  "password": "2jf70TPNZsS",
   "secondaryUsername": "archiveManager",
   "secondaryPassword": "aman"
 }

--- a/cypress/fixtures/rawDataset.json
+++ b/cypress/fixtures/rawDataset.json
@@ -21,7 +21,7 @@
   "license": "string",
   "version": "string",
   "isPublished": false,
-  "ownerGroup": "ess",
+  "ownerGroup": "cypress",
   "accessGroups": [],
   "createdBy": "string",
   "updatedBy": "string",

--- a/cypress/fixtures/rawDataset.json
+++ b/cypress/fixtures/rawDataset.json
@@ -21,7 +21,7 @@
   "license": "string",
   "version": "string",
   "isPublished": false,
-  "ownerGroup": "cypress",
+  "ownerGroup": "ess",
   "accessGroups": [],
   "createdBy": "string",
   "updatedBy": "string",

--- a/src/app/app-routing/app-routing.module.ts
+++ b/src/app/app-routing/app-routing.module.ts
@@ -87,7 +87,7 @@ export const routes: Routes = [
       {
         path: "login/error",
         component: ErrorPageComponent,
-        data: { message: "Location Not Found", breadcrumb: "Error" },
+        data: { errorTitle: "Location Not Found", breadcrumb: "Error" },
       },
     ],
   },
@@ -234,7 +234,7 @@ export const routes: Routes = [
       {
         path: "error",
         component: ErrorPageComponent,
-        data: { message: "Location Not Found", breadcrumb: "Error" },
+        data: { errorTitle: "Location Not Found"},
       },
       {
         path: "help/ingestManual",
@@ -257,8 +257,18 @@ export const routes: Routes = [
         component: LoginLayoutComponent,
         canActivate: [AuthGuard],
       },
+      {
+        path: "404",
+        component: ErrorPageComponent,
+        data: { errorTitle: "404 Page not found" , message: "Sorry, the page you are trying to view doesn't exists"}
+      },
     ],
   },
+  {
+    path: "**",
+    pathMatch: "full",
+    redirectTo: "/404",
+  }
 ];
 @NgModule({
   imports: [RouterModule.forRoot(routes, { relativeLinkResolution: "legacy" })],

--- a/src/app/datasets/anonymous-details-dashboard/anonymous-details-dashboard.component.html
+++ b/src/app/datasets/anonymous-details-dashboard/anonymous-details-dashboard.component.html
@@ -57,9 +57,9 @@
 </ng-container>
 <ng-container *ngIf="!(dataset$ | async) as dataset">
   <error-page
-  *ngIf="!(loading$ | async)"
-  [errorTitle]="'Dataset information not found'"
-  [message]="'The dataset you are trying to view is either does not exist or requires authentication.'"
+    *ngIf="!(loading$ | async)"
+    [errorTitle]="'Dataset not found'"
+    [message]="'The dataset you are trying to view is either does not exist or requires authentication.'"
   >
   </error-page>
 </ng-container>

--- a/src/app/datasets/anonymous-details-dashboard/anonymous-details-dashboard.component.html
+++ b/src/app/datasets/anonymous-details-dashboard/anonymous-details-dashboard.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="(dataset$ | async) as dataset">
+<ng-container *ngIf="(dataset$ | async) as dataset; else notfound">
   <mat-tab-group>
     <mat-tab>
       <ng-template mat-tab-label>
@@ -55,11 +55,11 @@
     </mat-tab>
   </mat-tab-group>
 </ng-container>
-<ng-container *ngIf="!(dataset$ | async) as dataset">
+<ng-template #notfound>
   <error-page
-    *ngIf="!(loading$ | async)"
+    *ngIf="(loading$ | async) === false"
     [errorTitle]="'Dataset not found'"
     [message]="'The dataset you are trying to view is either does not exist or requires authentication.'"
   >
   </error-page>
-</ng-container>
+</ng-template>

--- a/src/app/datasets/anonymous-details-dashboard/anonymous-details-dashboard.component.html
+++ b/src/app/datasets/anonymous-details-dashboard/anonymous-details-dashboard.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="dataset$ | async as dataset">
+<ng-container *ngIf="(dataset$ | async) as dataset">
   <mat-tab-group>
     <mat-tab>
       <ng-template mat-tab-label>
@@ -54,4 +54,12 @@
       <dataset-lifecycle [dataset]="dataset"></dataset-lifecycle>
     </mat-tab>
   </mat-tab-group>
+</ng-container>
+<ng-container *ngIf="!(dataset$ | async) as dataset">
+  <error-page
+  *ngIf="!(loading$ | async)"
+  [errorTitle]="'Dataset information not found'"
+  [message]="'The dataset you are trying to view is either does not exist or requires authentication.'"
+  >
+  </error-page>
 </ng-container>

--- a/src/app/datasets/anonymous-details-dashboard/anonymous-details-dashboard.component.html
+++ b/src/app/datasets/anonymous-details-dashboard/anonymous-details-dashboard.component.html
@@ -59,7 +59,7 @@
   <error-page
     *ngIf="(loading$ | async) === false"
     [errorTitle]="'Dataset not found'"
-    [message]="'The dataset you are trying to view is either does not exist or requires authentication.'"
+    [message]="'The dataset you are trying to view either doesn\'t exist or requires authentication.'"
   >
   </error-page>
 </ng-template>

--- a/src/app/datasets/anonymous-details-dashboard/anonymous-details-dashboard.component.ts
+++ b/src/app/datasets/anonymous-details-dashboard/anonymous-details-dashboard.component.ts
@@ -17,6 +17,7 @@ import { fetchSampleAction } from "state-management/actions/samples.actions";
 import { fetchProposalAction } from "state-management/actions/proposals.actions";
 import { getCurrentSample } from "state-management/selectors/samples.selectors";
 import { getCurrentProposal } from "state-management/selectors/proposals.selectors";
+import { getIsLoading } from "state-management/selectors/user.selectors";
 
 @Component({
   selector: "anonymous-details-dashboard",
@@ -25,6 +26,7 @@ import { getCurrentProposal } from "state-management/selectors/proposals.selecto
 })
 export class AnonymousDetailsDashboardComponent implements OnInit, OnDestroy {
   dataset$ = this.store.pipe(select(getCurrentDataset));
+  loading$ = this.store.pipe(select(getIsLoading));
   origDatablocks$ = this.store.pipe(select(getCurrentOrigDatablocks));
   attachments$ = this.store.pipe(select(getCurrentAttachments));
   proposal$ = this.store.pipe(select(getCurrentProposal));

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
@@ -141,7 +141,7 @@
 </ng-template>
 <ng-template [ngIf]="!dataset">
   <error-page
-    *ngIf="!(loading$ | async)"
+    *ngIf="(loading$ | async) === false"
     [errorTitle]="'Dataset not found'"
     [message]="'The dataset you are trying to view is either does not exist or you do not have permission to view it.'"
   >

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
@@ -143,7 +143,7 @@
   <error-page
     *ngIf="(loading$ | async) === false"
     [errorTitle]="'Dataset not found'"
-    [message]="'The dataset you are trying to view is either does not exist or you do not have permission to view it.'"
+    [message]="'The dataset you are trying to view either doesn\'t exist or you don\'t have permission to view it.'"
   >
   </error-page>
 </ng-template>

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
@@ -141,9 +141,9 @@
 </ng-template>
 <ng-template [ngIf]="!dataset">
   <error-page
-  *ngIf="!(loading$ | async)"
-  [errorTitle]="'Dataset information not found'"
-  [message]="'The dataset you are trying to view is either does not exist or you do not have permission to view it.'"
+    *ngIf="!(loading$ | async)"
+    [errorTitle]="'Dataset not found'"
+    [message]="'The dataset you are trying to view is either does not exist or you do not have permission to view it.'"
   >
   </error-page>
 </ng-template>

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
@@ -32,7 +32,7 @@
 
       <div style="clear: both;"></div>
 
-      <dataset-detail
+      <dataset-detail *ngIf="editingAllowed"
         [dataset]="dataset"
         [datasetWithout]="datasetWithout$ | async"
         [attachments]="attachments$ | async"
@@ -48,6 +48,14 @@
         (saveMetadata)="onSaveMetadata($event)"
         (hasUnsavedChanges)="onHasUnsavedChanges($event)"
       ></dataset-detail>
+      <!-- Viewing public dataset while in read only mode  -->
+      <anonymous-details *ngIf="!editingAllowed"
+        [dataset]="dataset"
+        [proposal]="proposal$ | async"
+        [sample]="sample$ | async"
+        [attachments]="attachments$ | async"
+        (clickKeyword)="onClickKeyword($event)"
+      ></anonymous-details>
     </mat-tab>
 
     <mat-tab>
@@ -130,4 +138,12 @@
       </mat-card>
     </mat-tab>
   </mat-tab-group>
+</ng-template>
+<ng-template [ngIf]="!dataset">
+  <error-page
+  *ngIf="!(loading$ | async)"
+  [errorTitle]="'Dataset information not found'"
+  [message]="'The dataset you are trying to view is either does not exist or you do not have permission to view it.'"
+  >
+  </error-page>
 </ng-template>

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
@@ -23,7 +23,7 @@ import {
   getIsLoading,
 } from "state-management/selectors/user.selectors";
 import { ActivatedRoute, Router } from "@angular/router";
-import { Subscription, Observable, fromEvent } from "rxjs";
+import { Subscription, Observable, fromEvent, combineLatest } from "rxjs";
 import { pluck, take, map } from "rxjs/operators";
 import { APP_CONFIG, AppConfig } from "app-config.module";
 import {
@@ -265,8 +265,8 @@ export class DatasetDetailsDashboardComponent
       this.store.pipe(select(getCurrentDataset)).subscribe((dataset) => {
         if (dataset) {
           this.dataset = dataset;
-          this.accessGroups$.subscribe((groups: string[]) => {
-            this.editingAllowed = groups.indexOf(this.dataset.ownerGroup) !== -1;
+          combineLatest([this.accessGroups$, this.isAdmin$]).subscribe(([groups, isAdmin]) => {
+            this.editingAllowed = (groups.indexOf(this.dataset.ownerGroup) !== -1) || isAdmin;
           });
           if ("proposalId" in dataset) {
             this.store.dispatch(

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
@@ -24,7 +24,7 @@ import {
 } from "state-management/selectors/user.selectors";
 import { ActivatedRoute, Router } from "@angular/router";
 import { Subscription, Observable, fromEvent } from "rxjs";
-import { pluck, take } from "rxjs/operators";
+import { pluck, take, map } from "rxjs/operators";
 import { APP_CONFIG, AppConfig } from "app-config.module";
 import {
   clearFacetsAction,
@@ -46,7 +46,6 @@ import { fetchSampleAction } from "state-management/actions/samples.actions";
 import { getCurrentSample } from "state-management/selectors/samples.selectors";
 import { EditableComponent } from "app-routing/pending-changes.guard";
 import { MatDialog } from "@angular/material/dialog";
-import { map } from "rxjs/operators";
 @Component({
   selector: "dataset-details-dashboard",
   templateUrl: "./dataset-details-dashboard.component.html",
@@ -72,7 +71,7 @@ export class DatasetDetailsDashboardComponent
   jwt$: Observable<any>;
   dataset: Dataset;
   user: User;
-  editingAllowed: boolean = false;
+  editingAllowed = false;
   pickedFile: ReadFile;
   attachment: Attachment;
   constructor(

--- a/src/app/shared/modules/error-page/error-page.component.html
+++ b/src/app/shared/modules/error-page/error-page.component.html
@@ -1,5 +1,7 @@
-<h1>Error</h1>
-<br>
-<h3>Message:</h3>
-<h3>{{message}}</h3>
+<div class="center">
+  <h1>{{errorTitle}}</h1>
+  <br>
+  <h3>{{message}}</h3>
+</div>
+
 

--- a/src/app/shared/modules/error-page/error-page.component.scss
+++ b/src/app/shared/modules/error-page/error-page.component.scss
@@ -1,0 +1,18 @@
+@import "../../../../theme.scss";
+.center{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  height: 30%;
+}
+h1{
+  font-size: 50px;
+  text-align: center;
+  color: mat-color($primary);
+}
+h3{
+  font-size: 20px;
+  text-align: center;
+  color: mat-color($primary);
+}

--- a/src/app/shared/modules/error-page/error-page.component.spec.ts
+++ b/src/app/shared/modules/error-page/error-page.component.spec.ts
@@ -25,7 +25,7 @@ describe("ErrorPageComponent", () => {
     fixture = TestBed.createComponent(ErrorPageComponent);
     component = fixture.componentInstance;
     component.errorTitle = "Error";
-    component.message = "Message"
+    component.message = "Message";
     fixture.detectChanges();
   });
 

--- a/src/app/shared/modules/error-page/error-page.component.spec.ts
+++ b/src/app/shared/modules/error-page/error-page.component.spec.ts
@@ -24,6 +24,8 @@ describe("ErrorPageComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ErrorPageComponent);
     component = fixture.componentInstance;
+    component.errorTitle = "Error";
+    component.message = "Message"
     fixture.detectChanges();
   });
 

--- a/src/app/shared/modules/error-page/error-page.component.ts
+++ b/src/app/shared/modules/error-page/error-page.component.ts
@@ -4,15 +4,22 @@ import { ActivatedRoute } from "@angular/router";
 @Component({
   selector: "error-page",
   templateUrl: "./error-page.component.html",
-  styleUrls: ["./error-page.component.css"]
+  styleUrls: ["./error-page.component.scss"]
 })
 export class ErrorPageComponent implements OnInit {
-  @Input()
-  message: string;
+  @Input() errorTitle: string;
+  @Input() message: string;
+
 
   constructor(private route: ActivatedRoute) {}
 
   ngOnInit() {
-    this.route.queryParams.subscribe(v => (this.message = v.message));
+    // get errorTitle and message from redirection
+    if(!this.errorTitle && !this.message){
+      this.route.data.subscribe(data => {
+        this.errorTitle = data.errorTitle;
+        this.message = data.message;
+      });
+    }
   }
 }

--- a/src/app/shared/pipes/json-head.pipe.ts
+++ b/src/app/shared/pipes/json-head.pipe.ts
@@ -28,7 +28,7 @@ export class JsonHeadPipe implements PipeTransform {
     let val2 = " ";
     if (key2 !== undefined) {
       const prop = value[key2];
-      if (prop && prop?.unit) {
+      if (prop?.unit) {
         val2 = prop.value.toString() + " " + prop.unit;
       }
     } else {

--- a/src/app/shared/pipes/json-head.pipe.ts
+++ b/src/app/shared/pipes/json-head.pipe.ts
@@ -28,7 +28,7 @@ export class JsonHeadPipe implements PipeTransform {
     let val2 = " ";
     if (key2 !== undefined) {
       const prop = value[key2];
-      if (prop.hasOwnProperty("unit") && prop.unit) {
+      if (prop && prop?.unit) {
         val2 = prop.value.toString() + " " + prop.unit;
       }
     } else {


### PR DESCRIPTION
## Description
This PR solves issue #762 and made some small changes to the ErrorPageComponent.
## Motivation
See issue #762 
## Fixes:
- View a private dataset without logging in.
   <img width="1426" alt="Screenshot 2021-05-05 at 09 43 05" src="https://user-images.githubusercontent.com/17545757/117110391-564c5c80-ad86-11eb-9f9b-7b07b97147c8.png">
- View public dataset while being logged in => return dataset details (was empty before)
- View private dataset that the user doesn't have access to.
![Screenshot 2021-05-05 at 09 47 10](https://user-images.githubusercontent.com/17545757/117110768-eee2dc80-ad86-11eb-9dcb-af25c3e3fa74.png)
- Invalid url redirects to /404
![Screenshot 2021-05-05 at 09 49 00](https://user-images.githubusercontent.com/17545757/117110929-2782b600-ad87-11eb-99da-46e3c4e5c5a5.png)
## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [x] Requires update of catamel API?


