### PR TITLE
Modified dockerfile to accept env during run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
-FROM nginx 
+FROM nginx:1.19-alpine
 
-ARG env=production
-# RUN ./node_modules/@angular/cli/bin/ng build --prod
-COPY scripts/nginx.conf /etc/nginx/nginx.conf
-COPY dist/${env} /usr/share/nginx/html  
+ENV env=development
+WORKDIR /usr/src/app
 
-EXPOSE 80
+#npm ci
+COPY . /usr/src/app
+RUN apk update && apk upgrade && \
+    apk add --update nodejs npm
+RUN npm ci
+
+#nginx config
+COPY ./scripts/nginx.conf /etc/nginx/
+RUN echo "npx ng build --configuration=\${env} --output-path /usr/share/nginx/html" > /docker-entrypoint.d/npx_ng_build.sh && \
+    chmod +x /docker-entrypoint.d/npx_ng_build.sh


### PR DESCRIPTION
In order to have one docker image for all the environments, current
dockerfile uses the env variable only during run time

## Motivation
Old version of Dockerfile was such that it required one build per environment. In this way, one image can be built for all the environments and the environment can be selected at run time.

The current Dockerfile is making use of [docker-entrypoint.d](https://github.com/nginxinc/docker-nginx/blob/464886ab21ebe4b036ceb36d7557bf491f6d9320/mainline/alpine/docker-entrypoint.sh) directory parsed by nginx docker-entrypoint.sh at run time. 