### PR TITLE
fix logic in appCofnig

### DIFF
--- a/src/app/app-config.module.ts
+++ b/src/app/app-config.module.ts
@@ -5,6 +5,7 @@ import { TableColumn } from "state-management/models";
 export const APP_CONFIG = new InjectionToken<AppConfig>("app.config");
 
 export class AppConfig {
+  lbBaseURL: string;
   externalAuthEndpoint: string;
   fileserverBaseURL: string;
   synapseBaseUrl: string;
@@ -50,6 +51,7 @@ export class AppConfig {
 }
 
 export const APP_DI_CONFIG: AppConfig = {
+  lbBaseURL: environment["lbBaseURL"] || "http://localhost:3000",
   externalAuthEndpoint: environment["externalAuthEndpoint"] || null,
   fileserverBaseURL: environment["fileserverBaseURL"] || null,
   synapseBaseUrl: environment["synapseBaseUrl"] || null,
@@ -105,7 +107,7 @@ export const APP_DI_CONFIG: AppConfig = {
   userProfileImageEnabled: environment["userProfileImageEnabled"] || false,
   userNamePromptEnabled: environment["userNamePromptEnabled"] || false,
   landingPage: environment["landingPage"] || null,
-  editPublishedData: environment["editPublishedData"] || true,
+  editPublishedData: (environment["editPublishedData"] === undefined) ? true: environment["editPublishedData"]
 };
 
 @NgModule({

--- a/src/app/publisheddata/publisheddata-details/publisheddata-details.component.html
+++ b/src/app/publisheddata/publisheddata-details/publisheddata-details.component.html
@@ -162,6 +162,7 @@
     <mat-card>
       <button
         mat-raised-button
+        id="editBtn"
         class="edit-button"
         color="primary"
         *ngIf="appConfig.editPublishedData"
@@ -169,7 +170,7 @@
       >
         Edit
       </button>
-      <ng-container *ngIf="appConfig.jsonMetadataEnabled">
+      <ng-container id="jsonMetadataContainer" *ngIf="appConfig.jsonMetadataEnabled">
         <button mat-stroked-button (click)="show = !show">
           {{ show ? "Hide MetaData" : "Show Metadata" }}
         </button>

--- a/src/app/publisheddata/publisheddata-details/publisheddata-details.component.spec.ts
+++ b/src/app/publisheddata/publisheddata-details/publisheddata-details.component.spec.ts
@@ -20,6 +20,13 @@ describe("PublisheddataDetailsComponent", () => {
   let component: PublisheddataDetailsComponent;
   let fixture: ComponentFixture<PublisheddataDetailsComponent>;
 
+  const appConfig =  {
+    editMetadataEnabled: true,
+    editPublishedData: true,
+    jsonMetadataEnabled: true
+  };
+
+
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [PublisheddataDetailsComponent],
@@ -41,9 +48,7 @@ describe("PublisheddataDetailsComponent", () => {
           { provide: PublishedDataApi, useClass: MockPublishedDataApi },
           {
             provide: APP_CONFIG,
-            useValue: {
-              editMetadataEnabled: true
-            }
+            useValue: appConfig
           }
         ]
       }
@@ -59,5 +64,22 @@ describe("PublisheddataDetailsComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  describe("appconfig settings", () => {
+    beforeEach(() => {
+      appConfig.editPublishedData = false;
+      appConfig.jsonMetadataEnabled = false;
+      fixture = TestBed.createComponent(PublisheddataDetailsComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+      TestBed.compileComponents();
+    });
+    it("button should not appear if not loginFormEnabled", () => {
+      const compiled = fixture.debugElement.nativeElement;
+      expect(compiled.querySelector("#editBtn")).toBeNull();
+      expect(compiled.querySelector("#jsonMetadataContainer")).toBeNull();
+    });
+
   });
 });


### PR DESCRIPTION
## Description

Fixes #777  

When working on creating settings in app-config.module.ts in a feature PR, I found I copied the setting for `editPublishedData` and found that the value was always true.

The way these settings are written, it appears that they are intended to have a default. However, the way `editPublishedData` is written, the value can never be false, since `false || true == true`

Additionally, it appears that most projects are using the `lbBaseURL`, but it is not defiend in `AppConfig`. So, for consistency, I added this field.

## Motivation

Fix it so that the code that uses editPublishedData can set to false if wanted.

## Fixes:

- added `lbBaseURL` to `AppConfig`
- fixed config logic so that `editPublishedData` can be set to false if configured

## Tests included/Docs Updated?
I added tests to the place that `editPublishedData` is used, to test that it's affecting the UI. But as I type this, I'm guessing that my real addition (change to the construction of how that variable is set in `AppConfig` isn't tested. Not quite sure how such an angular test would be constructed.