### PR TITLE
Lazy loading

### DIFF
--- a/src/app/_layout/layout.module.ts
+++ b/src/app/_layout/layout.module.ts
@@ -7,12 +7,12 @@ import { MatIconModule } from "@angular/material/icon";
 import { MatMenuModule } from "@angular/material/menu";
 import { MatToolbarModule } from "@angular/material/toolbar";
 import { RouterModule } from "@angular/router";
-import { DatasetsModule } from "datasets/datasets.module";
 import { AnonymousLayoutComponent } from "./anonymous-layout/anonymous-layout.component";
 import { AppLayoutComponent } from "./app-layout/app-layout.component";
 import { LoginHeaderComponent } from "./login-header/login-header.component";
 import { LoginLayoutComponent } from "./login-layout/login-layout.component";
-import { SharedCatanieModule } from "shared/shared.module";
+import { BatchCardModule } from "datasets/batch-card/batch-card.module";
+import { BreadcrumbModule } from "shared/modules/breadcrumb/breadcrumb.module";
 
 @NgModule({
   declarations: [
@@ -24,14 +24,14 @@ import { SharedCatanieModule } from "shared/shared.module";
   ],
   imports: [
     CommonModule,
-    DatasetsModule,
+    BatchCardModule,
     MatBadgeModule,
     MatButtonModule,
     MatIconModule,
     MatMenuModule,
     MatToolbarModule,
     RouterModule,
-    SharedCatanieModule
+    BreadcrumbModule
   ],
   exports: []
 })

--- a/src/app/app-routing/app-routing.module.ts
+++ b/src/app/app-routing/app-routing.module.ts
@@ -1,55 +1,10 @@
 import { NgModule } from "@angular/core";
 import { RouterModule, Routes } from "@angular/router";
 
-import { DashboardComponent } from "../datasets/dashboard/dashboard.component";
-import { DatafilesComponent } from "../datasets/datafiles/datafiles.component";
-import { DatablocksComponent } from "../datasets/datablocks-table/datablocks-table.component";
-import { DatasetDetailsDashboardComponent } from "datasets/dataset-details-dashboard/dataset-details-dashboard.component";
-
-import { JobsDashboardComponent } from "jobs/jobs-dashboard/jobs-dashboard.component";
-import { JobsDashboardNewComponent } from "jobs/jobs-dashboard-new/jobs-dashboard-new.component";
-
-import { JobsDetailComponent } from "../jobs/jobs-detail/jobs-detail.component";
-
 import { ErrorPageComponent } from "shared/modules/error-page/error-page.component";
-
-import { LoginComponent } from "../users/login/login.component";
-import { UserSettingsComponent } from "../users/user-settings/user-settings.component";
-
-import { ViewProposalPageComponent } from "../proposals/view-proposal-page/view-proposal-page.component";
-
-import { PublishComponent } from "datasets/publish/publish.component";
-import { AuthGuard } from "./auth.guard";
-import { BatchViewComponent } from "datasets/batch-view/batch-view.component";
-import { SampleDetailComponent } from "../samples/sample-detail/sample-detail.component";
-
-import { LogbooksDashboardComponent } from "../logbooks/logbooks-dashboard/logbooks-dashboard.component";
-import { LogbooksTableComponent } from "../logbooks/logbooks-table/logbooks-table.component";
-import { AboutComponent } from "about/about/about.component";
-import { HelpComponent } from "help/help/help.component";
-import { PublisheddataDashboardComponent } from "publisheddata/publisheddata-dashboard/publisheddata-dashboard.component";
-import { PublisheddataDetailsComponent } from "publisheddata/publisheddata-details/publisheddata-details.component";
-import { PublisheddataEditComponent } from "publisheddata/publisheddata-edit/publisheddata-edit.component";
-
-// handles external URLs by lookup in the env config
-import { RedirectGuard } from "app-routing/redirect.guard";
-import { ProposalDashboardComponent } from "proposals/proposal-dashboard/proposal-dashboard.component";
-import { SampleDashboardComponent } from "samples/sample-dashboard/sample-dashboard.component";
 import { LoginLayoutComponent } from "_layout/login-layout/login-layout.component";
 import { AppLayoutComponent } from "_layout/app-layout/app-layout.component";
-import { PoliciesDashboardComponent } from "policies/policies-dashboard/policies-dashboard.component";
-import { InstrumentsDashboardComponent } from "instruments/instruments-dashboard/instruments-dashboard.component";
-import { InstrumentDetailsComponent } from "instruments/instrument-details/instrument-details.component";
-import { AnonymousDashboardComponent } from "datasets/anonymous-dashboard/anonymous-dashboard.component";
-import { AnonymousDetailsDashboardComponent } from "datasets/anonymous-details-dashboard/anonymous-details-dashboard.component";
 import { AnonymousLayoutComponent } from "_layout/anonymous-layout/anonymous-layout.component";
-import { JobsGuard } from "app-routing/jobs.guard";
-import { PoliciesGuard } from "app-routing/policies.guard";
-import { LogbookGuard } from "app-routing/logbook.guard";
-import { FilesDashboardComponent } from "files/files-dashboard/files-dashboard.component";
-import { DatasetsGuard } from "./datasets.guard";
-import { LeavingPageGuard } from "./pending-changes.guard";
-import { ProposalDashboardNewComponent } from "proposals/proposal-dashboard-new/proposal-dashboard-new.component";
 
 export const routes: Routes = [
   {
@@ -63,19 +18,15 @@ export const routes: Routes = [
       },
       {
         path: "anonymous/datasets",
-        component: AnonymousDashboardComponent,
-      },
-      {
-        path: "anonymous/datasets/:id",
-        component: AnonymousDetailsDashboardComponent,
+        loadChildren: () => import("./lazy/public-datasets-routing/public-datasets.feature.module").then( m => m.PublicDatasetsFeatureModule)
       },
       {
         path: "anonymous/about",
-        component: AboutComponent,
+        loadChildren: () => import("./lazy/about-routing/about.feature.module").then( m => m.AboutFeatureModule)
       },
       {
         path: "anonymous/help",
-        component: HelpComponent,
+        loadChildren: () => import("./lazy/help-routing/help.feature.module").then( m => m.HelpFeatureModule)
       },
     ],
   },
@@ -84,11 +35,9 @@ export const routes: Routes = [
     component: LoginLayoutComponent,
     children: [
       { path: "", redirectTo: "/login", pathMatch: "full" },
-      { path: "login", component: LoginComponent },
       {
-        path: "login/error",
-        component: ErrorPageComponent,
-        data: { errorTitle: "Location Not Found", breadcrumb: "Error" },
+        path: "login",
+        loadChildren: () => import("./lazy/login-routing/login.feature.module").then( m => m.LoginFeatureModule)
       },
     ],
   },
@@ -102,166 +51,54 @@ export const routes: Routes = [
         pathMatch: "full",
       },
       {
-        path: "datasets/batch/publish",
-        component: PublishComponent,
-        canActivate: [AuthGuard],
-      },
-      {
         path: "datasets",
-        component: DashboardComponent,
-        canActivate: [DatasetsGuard],
-      },
-      {
-        path: "datasets/batch",
-        component: BatchViewComponent,
-        canActivate: [AuthGuard],
-      },
-      {
-        path: "datasets/:id",
-        component: DatasetDetailsDashboardComponent,
-        canActivate: [DatasetsGuard],
-        canDeactivate: [LeavingPageGuard]
-      },
-      {
-        path: "datasets/:id/datablocks",
-        component: DatablocksComponent,
-        canActivate: [DatasetsGuard],
-      },
-      {
-        path: "datasets/:id/datafiles",
-        component: DatafilesComponent,
-        canActivate: [DatasetsGuard],
+        loadChildren: () => import("./lazy/private-datasets-routing/private-datasets.feature.module").then( m  => m.PrivateDatasetsFeatureModule)
       },
       {
         path: "files",
-        component: FilesDashboardComponent,
-        canActivate: [AuthGuard],
+        loadChildren: () => import("./lazy/file-routing/file.feature.module").then( m => m.FileFeatureModule)
       },
       {
         path: "instruments",
-        component: InstrumentsDashboardComponent,
-        canActivate: [AuthGuard],
-      },
-      {
-        path: "instruments/:id",
-        component: InstrumentDetailsComponent,
-        canActivate: [AuthGuard],
+        loadChildren: () => import("./lazy/instruments-routing/instruments.feature.module").then( m => m.InstrumentsFeatureModule)
       },
       {
         path: "proposals",
-        component: ProposalDashboardNewComponent,
-        canActivate: [AuthGuard],
-      },
-      {
-        path: "proposalsold",
-        component: ProposalDashboardComponent,
-        canActivate: [AuthGuard],
-      },
-      {
-        path: "proposals/:id",
-        component: ViewProposalPageComponent,
-        canActivate: [AuthGuard],
+        loadChildren: () => import("./lazy/proposal-routing/proposal.feature.module").then( m => m.ProposalFeatureModule)
       },
       {
         path: "publishedDatasets",
-        component: PublisheddataDashboardComponent,
-        canActivate: [AuthGuard],
-      },
-      {
-        path: "publishedDatasets/:id/edit",
-        component: PublisheddataEditComponent,
-        canActivate: [AuthGuard],
-      },
-      {
-        path: "publishedDatasets/:id",
-        component: PublisheddataDetailsComponent,
-        canActivate: [AuthGuard],
+        loadChildren: () => import("./lazy/publisheddata-routing/publisheddata.feature.module").then( m => m.PublisheddataFeatureModule)
       },
       {
         path: "samples",
-        component: SampleDashboardComponent,
-        canActivate: [AuthGuard],
+        loadChildren: () => import("./lazy/samples-routing/samples.feature.module").then( m => m.SamplesFeatureModule)
       },
-      {
-        path: "samples/:id",
-        component: SampleDetailComponent,
-        canActivate: [AuthGuard],
-      },
-
       {
         path: "policies",
-        component: PoliciesDashboardComponent,
-        canActivate: [AuthGuard, PoliciesGuard],
+        loadChildren: () => import("./lazy/policies-routing/policies.feature.module").then( m => m.PoliciesFeatureModule)
       },
 
       {
         path: "user",
-        component: UserSettingsComponent,
-        canActivate: [AuthGuard],
-      },
-      {
-        path: "user/settings",
-        component: UserSettingsComponent,
-        canActivate: [AuthGuard],
-      },
-      {
-        path: "user/jobsold",
-        component: JobsDashboardComponent,
-        canActivate: [AuthGuard, JobsGuard],
-      },
-      {
-        path: "user/jobs",
-        component: JobsDashboardNewComponent,
-        canActivate: [AuthGuard, JobsGuard],
-      },
-      {
-        path: "user/jobs/:id",
-        component: JobsDetailComponent,
-        canActivate: [AuthGuard, JobsGuard],
+        loadChildren: () => import("./lazy/user-routing/user.feature.module").then( m => m.UsersFeatureModule)
       },
       {
         path: "about",
-        component: AboutComponent,
+        loadChildren: () => import("./lazy/about-routing/about.feature.module").then( m => m.AboutFeatureModule)
       },
       {
         path: "help",
-        component: HelpComponent,
+        loadChildren: () => import("./lazy/help-routing/help.feature.module").then( m => m.HelpFeatureModule)
       },
       {
         path: "logbooks",
-        component: LogbooksTableComponent,
-        canActivate: [AuthGuard, LogbookGuard],
-      },
-      {
-        path: "logbooks/:name",
-        component: LogbooksDashboardComponent,
-        canActivate: [AuthGuard, LogbookGuard],
+        loadChildren: () => import("./lazy/logbooks-routing/logbooks.feature.module").then( m => m.LogbooksFeatureModule)
       },
       {
         path: "error",
         component: ErrorPageComponent,
         data: { errorTitle: "Location Not Found"},
-      },
-      {
-        path: "help/ingestManual",
-        canActivate: [RedirectGuard],
-        component: RedirectGuard,
-        data: {
-          urlConfigItem: "ingestManual",
-        },
-      },
-      {
-        path: "help/SciCatGettingStartedSLSSummary",
-        canActivate: [RedirectGuard],
-        component: RedirectGuard,
-        data: {
-          urlConfigItem: "gettingStarted",
-        },
-      },
-      {
-        path: "logout",
-        component: LoginLayoutComponent,
-        canActivate: [AuthGuard],
       },
       {
         path: "404",

--- a/src/app/app-routing/lazy/about-routing/about.feature.module.ts
+++ b/src/app/app-routing/lazy/about-routing/about.feature.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from "@angular/core";
+import { AboutRoutingModule } from "./about.routing.module";
+import { AboutModule } from "about/about.module";
+
+@NgModule({
+  imports: [
+    AboutModule,
+    AboutRoutingModule
+  ]
+})
+export class AboutFeatureModule {}

--- a/src/app/app-routing/lazy/about-routing/about.routing.module.ts
+++ b/src/app/app-routing/lazy/about-routing/about.routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from "@angular/core";
+import { RouterModule, Routes } from "@angular/router";
+import { AboutComponent } from "about/about/about.component";
+
+const routes: Routes = [
+  {
+    path: "",
+    component: AboutComponent,
+  }
+];
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class AboutRoutingModule {
+  constructor() {}
+}

--- a/src/app/app-routing/lazy/file-routing/file.feature.module.ts
+++ b/src/app/app-routing/lazy/file-routing/file.feature.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from "@angular/core";
+import { FilesModule } from "files/files.module";
+import { FilesRoutingModule } from "./file.routing.module";
+
+@NgModule({
+  imports: [
+    FilesModule,
+    FilesRoutingModule
+  ]
+})
+export class FileFeatureModule {}

--- a/src/app/app-routing/lazy/file-routing/file.routing.module.ts
+++ b/src/app/app-routing/lazy/file-routing/file.routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from "@angular/core";
+import { RouterModule, Routes } from "@angular/router";
+import { AuthGuard } from "app-routing/auth.guard";
+import { FilesDashboardComponent } from "files/files-dashboard/files-dashboard.component";
+
+const routes: Routes = [
+  {
+    path: "",
+    component: FilesDashboardComponent,
+    canActivate: [AuthGuard],
+  },
+];
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class FilesRoutingModule {}

--- a/src/app/app-routing/lazy/help-routing/help.feature.module.ts
+++ b/src/app/app-routing/lazy/help-routing/help.feature.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from "@angular/core";
+import { HelpRoutingModule } from "./help.routing.module";
+import { HelpModule } from "help/help.module";
+
+@NgModule({
+  imports: [
+    HelpModule,
+    HelpRoutingModule
+  ]
+})
+export class HelpFeatureModule {}

--- a/src/app/app-routing/lazy/help-routing/help.routing.module.ts
+++ b/src/app/app-routing/lazy/help-routing/help.routing.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from "@angular/core";
+import { RouterModule, Routes } from "@angular/router";
+import { HelpComponent } from "help/help/help.component";
+
+const routes: Routes = [
+  {
+    path: "",
+    component: HelpComponent,
+  }
+];
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class HelpRoutingModule {}

--- a/src/app/app-routing/lazy/instruments-routing/instruments.feature.module.ts
+++ b/src/app/app-routing/lazy/instruments-routing/instruments.feature.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from "@angular/core";
+import { InstrumentsModule } from "instruments/instruments.module";
+import { InstrumentsRoutingModule } from "./instruments.routing.module";
+
+@NgModule({
+  imports: [
+    InstrumentsModule,
+    InstrumentsRoutingModule
+  ]
+})
+export class InstrumentsFeatureModule {}

--- a/src/app/app-routing/lazy/instruments-routing/instruments.routing.module.ts
+++ b/src/app/app-routing/lazy/instruments-routing/instruments.routing.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from "@angular/core";
+import { RouterModule, Routes } from "@angular/router";
+import { AuthGuard } from "app-routing/auth.guard";
+import { InstrumentDetailsComponent } from "instruments/instrument-details/instrument-details.component";
+import { InstrumentsDashboardComponent } from "instruments/instruments-dashboard/instruments-dashboard.component";
+
+const routes: Routes = [
+  {
+    path: "",
+    component: InstrumentsDashboardComponent,
+    canActivate: [AuthGuard],
+  },
+  {
+    path: ":id",
+    component: InstrumentDetailsComponent,
+    canActivate: [AuthGuard],
+  },
+];
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class InstrumentsRoutingModule {}

--- a/src/app/app-routing/lazy/logbooks-routing/logbooks.feature.module.ts
+++ b/src/app/app-routing/lazy/logbooks-routing/logbooks.feature.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from "@angular/core";
+import { LogbooksModule } from "logbooks/logbooks.module";
+import { LogbooksRoutingModule } from "./logbooks.routing.module";
+
+@NgModule({
+  imports: [
+    LogbooksModule,
+    LogbooksRoutingModule
+  ]
+})
+export class LogbooksFeatureModule {}

--- a/src/app/app-routing/lazy/logbooks-routing/logbooks.routing.module.ts
+++ b/src/app/app-routing/lazy/logbooks-routing/logbooks.routing.module.ts
@@ -1,0 +1,26 @@
+import { NgModule } from "@angular/core";
+import { RouterModule, Routes } from "@angular/router";
+import { AuthGuard } from "app-routing/auth.guard";
+import { LogbookGuard } from "app-routing/logbook.guard";
+import { LogbooksDashboardComponent } from "logbooks/logbooks-dashboard/logbooks-dashboard.component";
+import { LogbooksTableComponent } from "logbooks/logbooks-table/logbooks-table.component";
+
+
+const routes: Routes = [
+
+  {
+    path: "",
+    component: LogbooksTableComponent,
+    canActivate: [AuthGuard, LogbookGuard],
+  },
+  {
+    path: ":name",
+    component: LogbooksDashboardComponent,
+    canActivate: [AuthGuard, LogbookGuard],
+  },
+];
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class LogbooksRoutingModule {}

--- a/src/app/app-routing/lazy/login-routing/login.feature.module.ts
+++ b/src/app/app-routing/lazy/login-routing/login.feature.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from "@angular/core";
+import { UsersModule } from "users/users.module";
+import { LoginRoutingModule } from "./login.routing.module";
+
+@NgModule({
+  imports: [
+    UsersModule,
+    LoginRoutingModule
+  ]
+})
+export class LoginFeatureModule {}

--- a/src/app/app-routing/lazy/login-routing/login.routing.module.ts
+++ b/src/app/app-routing/lazy/login-routing/login.routing.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from "@angular/core";
+import { RouterModule, Routes } from "@angular/router";
+import { LoginComponent } from "users/login/login.component";
+
+const routes: Routes = [
+  {
+    path: "",
+    component: LoginComponent,
+  }
+];
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class LoginRoutingModule {}

--- a/src/app/app-routing/lazy/policies-routing/policies.feature.module.ts
+++ b/src/app/app-routing/lazy/policies-routing/policies.feature.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from "@angular/core";
+import { PoliciesModule } from "policies/policies.module";
+import { PoliciesRoutingModule } from "./policies.routing.module";
+
+@NgModule({
+  imports: [
+    PoliciesModule,
+    PoliciesRoutingModule
+  ]
+})
+export class PoliciesFeatureModule {}

--- a/src/app/app-routing/lazy/policies-routing/policies.routing.module.ts
+++ b/src/app/app-routing/lazy/policies-routing/policies.routing.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from "@angular/core";
+import { RouterModule, Routes } from "@angular/router";
+import { AuthGuard } from "app-routing/auth.guard";
+import { PoliciesGuard } from "app-routing/policies.guard";
+import { PoliciesDashboardComponent } from "policies/policies-dashboard/policies-dashboard.component";
+
+const routes: Routes = [
+  {
+    path: "",
+    component: PoliciesDashboardComponent,
+    canActivate: [AuthGuard, PoliciesGuard],
+  },
+];
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class PoliciesRoutingModule {}

--- a/src/app/app-routing/lazy/private-datasets-routing/private-datasets.feature.module.ts
+++ b/src/app/app-routing/lazy/private-datasets-routing/private-datasets.feature.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from "@angular/core";
+import { DatasetsModule } from "datasets/datasets.module";
+import { PrivateDatasetsRoutingModule } from "./private-datasets.routing.module";
+@NgModule({
+  imports: [
+    DatasetsModule,
+    PrivateDatasetsRoutingModule
+  ]
+})
+export class PrivateDatasetsFeatureModule {}

--- a/src/app/app-routing/lazy/private-datasets-routing/private-datasets.routing.module.ts
+++ b/src/app/app-routing/lazy/private-datasets-routing/private-datasets.routing.module.ts
@@ -37,12 +37,6 @@ const routes: Routes = [
     component: DatablocksComponent,
     canActivate: [DatasetsGuard],
   },
-  // Do we need this path? seems like one could go to datafile in dataset detail
-  // {
-  //   path: ":id/datafiles",
-  //   component: DatafilesComponent,
-  //   canActivate: [DatasetsGuard],
-  // },
 ];
 @NgModule({
   imports: [RouterModule.forChild(routes)],

--- a/src/app/app-routing/lazy/private-datasets-routing/private-datasets.routing.module.ts
+++ b/src/app/app-routing/lazy/private-datasets-routing/private-datasets.routing.module.ts
@@ -1,0 +1,52 @@
+import { NgModule } from "@angular/core";
+import { RouterModule, Routes } from "@angular/router";
+import { AuthGuard } from "app-routing/auth.guard";
+import { DatasetsGuard } from "app-routing/datasets.guard";
+import { LeavingPageGuard } from "app-routing/pending-changes.guard";
+import { BatchViewComponent } from "datasets/batch-view/batch-view.component";
+import { DashboardComponent } from "datasets/dashboard/dashboard.component";
+import { DatablocksComponent } from "datasets/datablocks-table/datablocks-table.component";
+import { DatasetDetailsDashboardComponent } from "datasets/dataset-details-dashboard/dataset-details-dashboard.component";
+import { PublishComponent } from "datasets/publish/publish.component";
+
+
+const routes: Routes = [
+  {
+    path: "",
+    component: DashboardComponent,
+    canActivate: [AuthGuard],
+  },
+  {
+    path: "batch",
+    component: BatchViewComponent,
+    canActivate: [AuthGuard],
+  },
+  {
+    path: "batch/publish",
+    component: PublishComponent,
+    canActivate: [AuthGuard],
+  },
+  {
+    path: ":id",
+    component: DatasetDetailsDashboardComponent,
+    canActivate: [DatasetsGuard],
+    canDeactivate: [LeavingPageGuard]
+  },
+  {
+    path: ":id/datablocks",
+    component: DatablocksComponent,
+    canActivate: [DatasetsGuard],
+  },
+  // Do we need this path? seems like one could go to datafile in dataset detail
+  // {
+  //   path: ":id/datafiles",
+  //   component: DatafilesComponent,
+  //   canActivate: [DatasetsGuard],
+  // },
+]
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+  providers: [],
+})
+export class PrivateDatasetsRoutingModule {}

--- a/src/app/app-routing/lazy/private-datasets-routing/private-datasets.routing.module.ts
+++ b/src/app/app-routing/lazy/private-datasets-routing/private-datasets.routing.module.ts
@@ -43,7 +43,7 @@ const routes: Routes = [
   //   component: DatafilesComponent,
   //   canActivate: [DatasetsGuard],
   // },
-]
+];
 @NgModule({
   imports: [RouterModule.forChild(routes)],
   exports: [RouterModule],

--- a/src/app/app-routing/lazy/proposal-routing/proposal.feature.module.ts
+++ b/src/app/app-routing/lazy/proposal-routing/proposal.feature.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from "@angular/core";
+import { ProposalsModule } from "proposals/proposals.module";
+import { ProposalsRoutingModule } from "./proposal.routing.module";
+
+@NgModule({
+  imports: [
+    ProposalsModule,
+    ProposalsRoutingModule
+  ]
+})
+export class ProposalFeatureModule {}

--- a/src/app/app-routing/lazy/proposal-routing/proposal.routing.module.ts
+++ b/src/app/app-routing/lazy/proposal-routing/proposal.routing.module.ts
@@ -11,12 +11,6 @@ const routes: Routes = [
     component: ProposalDashboardNewComponent,
     canActivate: [AuthGuard],
   },
-  // Can we remove this?
-  // {
-  //   path: "old",
-  //   component: ProposalDashboardComponent,
-  //   canActivate: [AuthGuard],
-  // },
   {
     path: ":id",
     component: ViewProposalPageComponent,

--- a/src/app/app-routing/lazy/proposal-routing/proposal.routing.module.ts
+++ b/src/app/app-routing/lazy/proposal-routing/proposal.routing.module.ts
@@ -1,0 +1,30 @@
+import { NgModule } from "@angular/core";
+import { RouterModule, Routes } from "@angular/router";
+import { AuthGuard } from "app-routing/auth.guard";
+import { ProposalDashboardNewComponent } from "proposals/proposal-dashboard-new/proposal-dashboard-new.component";
+import { ViewProposalPageComponent } from "proposals/view-proposal-page/view-proposal-page.component";
+
+const routes: Routes = [
+
+  {
+    path: "",
+    component: ProposalDashboardNewComponent,
+    canActivate: [AuthGuard],
+  },
+  // Can we remove this?
+  // {
+  //   path: "old",
+  //   component: ProposalDashboardComponent,
+  //   canActivate: [AuthGuard],
+  // },
+  {
+    path: ":id",
+    component: ViewProposalPageComponent,
+    canActivate: [AuthGuard],
+  },
+];
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class ProposalsRoutingModule {}

--- a/src/app/app-routing/lazy/public-datasets-routing/public-datasets.feature.module.ts
+++ b/src/app/app-routing/lazy/public-datasets-routing/public-datasets.feature.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from "@angular/core";
+import { DatasetsModule } from "datasets/datasets.module";
+import { PublicDatasetsRoutingModule } from "./public-datasets.routing.module";
+
+@NgModule({
+  imports: [
+    DatasetsModule,
+    PublicDatasetsRoutingModule
+  ]
+})
+export class PublicDatasetsFeatureModule {}

--- a/src/app/app-routing/lazy/public-datasets-routing/public-datasets.routing.module.ts
+++ b/src/app/app-routing/lazy/public-datasets-routing/public-datasets.routing.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from "@angular/core";
+import { RouterModule, Routes } from "@angular/router";
+import { AnonymousDashboardComponent } from "datasets/anonymous-dashboard/anonymous-dashboard.component";
+import { AnonymousDetailsDashboardComponent } from "datasets/anonymous-details-dashboard/anonymous-details-dashboard.component";
+import { AnonymousDetailsComponent } from "datasets/anonymous-details/anonymous-details.component";
+
+const routes: Routes = [
+  {
+    path: "",
+    component: AnonymousDashboardComponent,
+  },
+  {
+    path: ":id",
+    component: AnonymousDetailsDashboardComponent,
+  },
+]
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+  providers: [],
+})
+export class PublicDatasetsRoutingModule {}

--- a/src/app/app-routing/lazy/public-datasets-routing/public-datasets.routing.module.ts
+++ b/src/app/app-routing/lazy/public-datasets-routing/public-datasets.routing.module.ts
@@ -13,7 +13,7 @@ const routes: Routes = [
     path: ":id",
     component: AnonymousDetailsDashboardComponent,
   },
-]
+];
 @NgModule({
   imports: [RouterModule.forChild(routes)],
   exports: [RouterModule],

--- a/src/app/app-routing/lazy/public-datasets-routing/public-datasets.routing.module.ts
+++ b/src/app/app-routing/lazy/public-datasets-routing/public-datasets.routing.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from "@angular/core";
 import { RouterModule, Routes } from "@angular/router";
 import { AnonymousDashboardComponent } from "datasets/anonymous-dashboard/anonymous-dashboard.component";
 import { AnonymousDetailsDashboardComponent } from "datasets/anonymous-details-dashboard/anonymous-details-dashboard.component";
-import { AnonymousDetailsComponent } from "datasets/anonymous-details/anonymous-details.component";
 
 const routes: Routes = [
   {

--- a/src/app/app-routing/lazy/publisheddata-routing/publisheddata.feature.module.ts
+++ b/src/app/app-routing/lazy/publisheddata-routing/publisheddata.feature.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from "@angular/core";
+import { PublisheddataModule } from "publisheddata/publisheddata.module";
+import { PublisheddataRoutingModule } from "./publisheddata.routing.module";
+
+@NgModule({
+  imports: [
+    PublisheddataModule,
+    PublisheddataRoutingModule
+  ]
+})
+export class PublisheddataFeatureModule {}

--- a/src/app/app-routing/lazy/publisheddata-routing/publisheddata.routing.module.ts
+++ b/src/app/app-routing/lazy/publisheddata-routing/publisheddata.routing.module.ts
@@ -1,0 +1,29 @@
+import { NgModule } from "@angular/core";
+import { RouterModule, Routes } from "@angular/router";
+import { AuthGuard } from "app-routing/auth.guard";
+import { PublisheddataDashboardComponent } from "publisheddata/publisheddata-dashboard/publisheddata-dashboard.component";
+import { PublisheddataDetailsComponent } from "publisheddata/publisheddata-details/publisheddata-details.component";
+import { PublisheddataEditComponent } from "publisheddata/publisheddata-edit/publisheddata-edit.component";
+
+const routes: Routes = [
+  {
+    path: "",
+    component: PublisheddataDashboardComponent,
+    canActivate: [AuthGuard],
+  },
+  {
+    path: ":id",
+    component: PublisheddataDetailsComponent,
+    canActivate: [AuthGuard],
+  },
+  {
+    path: ":id/edit",
+    component: PublisheddataEditComponent,
+    canActivate: [AuthGuard],
+  }
+];
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class PublisheddataRoutingModule {}

--- a/src/app/app-routing/lazy/samples-routing/samples.feature.module.ts
+++ b/src/app/app-routing/lazy/samples-routing/samples.feature.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from "@angular/core";
+import { SamplesModule } from "samples/samples.module";
+import { SamplesRoutingModule } from "./samples.routing.module";
+
+@NgModule({
+  imports: [
+    SamplesModule,
+    SamplesRoutingModule
+  ]
+})
+export class SamplesFeatureModule {}

--- a/src/app/app-routing/lazy/samples-routing/samples.routing.module.ts
+++ b/src/app/app-routing/lazy/samples-routing/samples.routing.module.ts
@@ -1,0 +1,24 @@
+import { NgModule } from "@angular/core";
+import { RouterModule, Routes } from "@angular/router";
+import { AuthGuard } from "app-routing/auth.guard";
+import { SampleDashboardComponent } from "samples/sample-dashboard/sample-dashboard.component";
+import { SampleDetailComponent } from "samples/sample-detail/sample-detail.component";
+
+const routes: Routes = [
+
+  {
+    path: "",
+    component: SampleDashboardComponent,
+    canActivate: [AuthGuard],
+  },
+  {
+    path: ":id",
+    component: SampleDetailComponent,
+    canActivate: [AuthGuard],
+  },
+];
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class SamplesRoutingModule { }

--- a/src/app/app-routing/lazy/user-routing/user.feature.module.ts
+++ b/src/app/app-routing/lazy/user-routing/user.feature.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from "@angular/core";
+import { UsersModule } from "users/users.module";
+import { UsersRoutingModule } from "./user.routing.module";
+
+@NgModule({
+  imports: [
+    UsersModule,
+    UsersRoutingModule
+  ]
+})
+export class UsersFeatureModule {}

--- a/src/app/app-routing/lazy/user-routing/user.feature.module.ts
+++ b/src/app/app-routing/lazy/user-routing/user.feature.module.ts
@@ -1,10 +1,12 @@
 import { NgModule } from "@angular/core";
+import { JobsModule } from "jobs/jobs.module";
 import { UsersModule } from "users/users.module";
 import { UsersRoutingModule } from "./user.routing.module";
 
 @NgModule({
   imports: [
     UsersModule,
+    JobsModule,
     UsersRoutingModule
   ]
 })

--- a/src/app/app-routing/lazy/user-routing/user.routing.module.ts
+++ b/src/app/app-routing/lazy/user-routing/user.routing.module.ts
@@ -18,12 +18,6 @@ const routes: Routes = [
       component: UserSettingsComponent,
       canActivate: [AuthGuard],
     },
-    // Can we remove this?
-    // {
-    //   path: "old",
-    //   component: JobsDashboardComponent,
-    //   canActivate: [AuthGuard, JobsGuard],
-    // },
     {
       path: "jobs",
       component: JobsDashboardNewComponent,

--- a/src/app/app-routing/lazy/user-routing/user.routing.module.ts
+++ b/src/app/app-routing/lazy/user-routing/user.routing.module.ts
@@ -1,0 +1,42 @@
+import { NgModule } from "@angular/core";
+import { RouterModule, Routes } from "@angular/router";
+import { AuthGuard } from "app-routing/auth.guard";
+import { JobsGuard } from "app-routing/jobs.guard";
+import { JobsDashboardNewComponent } from "jobs/jobs-dashboard-new/jobs-dashboard-new.component";
+import { JobsDetailComponent } from "jobs/jobs-detail/jobs-detail.component";
+import { UserSettingsComponent } from "users/user-settings/user-settings.component";
+
+const routes: Routes = [
+  {
+    path: "",
+      component: UserSettingsComponent,
+      pathMatch: "full",
+      canActivate: [AuthGuard],
+    },
+    {
+      path: "settings",
+      component: UserSettingsComponent,
+      canActivate: [AuthGuard],
+    },
+    // Can we remove this?
+    // {
+    //   path: "old",
+    //   component: JobsDashboardComponent,
+    //   canActivate: [AuthGuard, JobsGuard],
+    // },
+    {
+      path: "jobs",
+      component: JobsDashboardNewComponent,
+      canActivate: [AuthGuard, JobsGuard],
+    },
+    {
+      path: "jobs/:id",
+      component: JobsDetailComponent,
+      canActivate: [AuthGuard, JobsGuard],
+    },
+];
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class UsersRoutingModule {}

--- a/src/app/app-routing/pending-changes.guard.ts
+++ b/src/app/app-routing/pending-changes.guard.ts
@@ -1,5 +1,4 @@
 import { Injectable } from "@angular/core";
-import { MatDialog } from "@angular/material/dialog";
 import {
   CanDeactivate,
 } from "@angular/router";
@@ -22,7 +21,7 @@ export class LeavingPageGuard implements CanDeactivate<EditableComponent> {
   /**
    * Needs to return either a boolean or an observable that maps to a boolean
    */
-  constructor(private dialog: MatDialog){}
+  constructor(){}
   canDeactivate(component: EditableComponent): Observable<boolean> | boolean {
     return component.hasUnsavedChanges()?
       confirm("You have unsaved changes. Press Cancel to go back and save these changes, or OK to leave without saving")

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -65,10 +65,9 @@ export class AppComponent implements OnDestroy, OnInit, AfterViewChecked {
    * @memberof AppComponent
    */
   ngOnInit() {
-    this.store.dispatch(fetchCurrentUserAction());
     LoopBackConfig.setBaseURL(this.appConfig.lbBaseURL);
     console.log(LoopBackConfig.getPath());
-
+    this.store.dispatch(fetchCurrentUserAction());
     if (window.location.pathname.indexOf("logout") !== -1) {
       this.logout();
     }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -17,7 +17,6 @@ import { SamplesModule } from "./samples/samples.module";
 import { SharedCatanieModule } from "shared/shared.module";
 import { StoreModule } from "@ngrx/store";
 import { UserApi } from "shared/sdk/services";
-import { UsersModule } from "users/users.module";
 import { routerReducer } from "@ngrx/router-store";
 import { extModules } from "./build-specifics";
 
@@ -31,8 +30,6 @@ import { MatToolbarModule } from "@angular/material/toolbar";
 import { ServiceWorkerModule } from "@angular/service-worker";
 import { environment } from "../environments/environment";
 import { LogbooksModule } from "./logbooks/logbooks.module";
-import { AboutModule } from "about/about.module";
-import { HelpModule } from "help/help.module";
 import { PublisheddataModule } from "publisheddata/publisheddata.module";
 import { LayoutModule } from "_layout/layout.module";
 import { JobsModule } from "jobs/jobs.module";
@@ -44,17 +41,12 @@ import { MatDatepickerModule } from "@angular/material/datepicker";
 @NgModule({
   declarations: [AppComponent],
   imports: [
-    AboutModule,
     AppConfigModule,
     AppRoutingModule,
     BrowserAnimationsModule,
     BrowserModule,
-    DatasetsModule,
-    FilesModule,
     FlexLayoutModule,
-    HelpModule,
     HttpClientModule,
-    InstrumentsModule,
     JobsModule,
     LogbooksModule,
     LayoutModule,
@@ -68,12 +60,7 @@ import { MatDatepickerModule } from "@angular/material/datepicker";
     MatToolbarModule,
     MatButtonModule,
     MatButtonToggleModule,
-    PoliciesModule,
-    ProposalsModule,
-    PublisheddataModule,
-    SamplesModule,
     SharedCatanieModule,
-    UsersModule,
     SDKBrowserModule.forRoot(),
     StoreModule.forRoot(
       { router: routerReducer, users: userReducer },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -4,40 +4,21 @@ import { AppConfigModule } from "app-config.module";
 import { AppRoutingModule, routes } from "app-routing/app-routing.module";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { BrowserModule, Title } from "@angular/platform-browser";
-import { DatasetsModule } from "datasets/datasets.module";
 import { EffectsModule } from "@ngrx/effects";
-import { FlexLayoutModule } from "@angular/flex-layout";
 import { HttpClientModule } from "@angular/common/http";
 import { NgModule } from "@angular/core";
-import { PoliciesModule } from "policies/policies.module";
-import { ProposalsModule } from "proposals/proposals.module";
 import { RouterModule } from "@angular/router";
 import { SampleApi, SDKBrowserModule } from "shared/sdk/index";
-import { SamplesModule } from "./samples/samples.module";
-import { SharedCatanieModule } from "shared/shared.module";
 import { StoreModule } from "@ngrx/store";
 import { UserApi } from "shared/sdk/services";
 import { routerReducer } from "@ngrx/router-store";
 import { extModules } from "./build-specifics";
-
-import { MatBadgeModule } from "@angular/material/badge";
 import { MatNativeDateModule } from "@angular/material/core";
-import { MatIconModule } from "@angular/material/icon";
-import { MatMenuModule } from "@angular/material/menu";
 import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
 import { MatSnackBarModule } from "@angular/material/snack-bar";
-import { MatToolbarModule } from "@angular/material/toolbar";
 import { ServiceWorkerModule } from "@angular/service-worker";
 import { environment } from "../environments/environment";
-import { LogbooksModule } from "./logbooks/logbooks.module";
-import { PublisheddataModule } from "publisheddata/publisheddata.module";
 import { LayoutModule } from "_layout/layout.module";
-import { JobsModule } from "jobs/jobs.module";
-import { InstrumentsModule } from "./instruments/instruments.module";
-import { FilesModule } from "files/files.module";
-import { MatButtonModule } from "@angular/material/button";
-import { MatButtonToggleModule } from "@angular/material/button-toggle";
-import { MatDatepickerModule } from "@angular/material/datepicker";
 @NgModule({
   declarations: [AppComponent],
   imports: [
@@ -45,22 +26,10 @@ import { MatDatepickerModule } from "@angular/material/datepicker";
     AppRoutingModule,
     BrowserAnimationsModule,
     BrowserModule,
-    FlexLayoutModule,
     HttpClientModule,
-    JobsModule,
-    LogbooksModule,
     LayoutModule,
-    MatBadgeModule,
-    MatDatepickerModule,
-    MatIconModule,
-    MatMenuModule,
-    MatNativeDateModule,
     MatProgressSpinnerModule,
     MatSnackBarModule,
-    MatToolbarModule,
-    MatButtonModule,
-    MatButtonToggleModule,
-    SharedCatanieModule,
     SDKBrowserModule.forRoot(),
     StoreModule.forRoot(
       { router: routerReducer, users: userReducer },

--- a/src/app/datasets/batch-card/batch-card.module.ts
+++ b/src/app/datasets/batch-card/batch-card.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from "@angular/core";
 import { MatButtonModule } from "@angular/material/button";
 import { MatCardModule } from "@angular/material/card";
 import { MatIconModule } from "@angular/material/icon";
+import { RouterModule } from "@angular/router";
 import { StoreModule } from "@ngrx/store";
 import { datasetsReducer } from "state-management/reducers/datasets.reducer";
 import { ADAuthService } from "users/adauth.service";
@@ -14,6 +15,7 @@ import { BatchCardComponent } from "./batch-card.component";
     MatButtonModule,
     MatCardModule,
     MatIconModule,
+    RouterModule,
     StoreModule.forFeature("datasets", datasetsReducer)
   ],
   declarations: [

--- a/src/app/datasets/batch-card/batch-card.module.ts
+++ b/src/app/datasets/batch-card/batch-card.module.ts
@@ -1,0 +1,26 @@
+import { CommonModule } from "@angular/common";
+import { NgModule } from "@angular/core";
+import { MatButtonModule } from "@angular/material/button";
+import { MatCardModule } from "@angular/material/card";
+import { MatIconModule } from "@angular/material/icon";
+import { ADAuthService } from "users/adauth.service";
+import { BatchCardComponent } from "./batch-card.component";
+
+@NgModule({
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatCardModule,
+    MatIconModule,
+  ],
+  declarations: [
+    BatchCardComponent
+  ],
+  providers: [
+    ADAuthService,
+  ],
+  exports: [
+    BatchCardComponent,
+  ],
+})
+export class BatchCardModule {}

--- a/src/app/datasets/batch-card/batch-card.module.ts
+++ b/src/app/datasets/batch-card/batch-card.module.ts
@@ -3,6 +3,8 @@ import { NgModule } from "@angular/core";
 import { MatButtonModule } from "@angular/material/button";
 import { MatCardModule } from "@angular/material/card";
 import { MatIconModule } from "@angular/material/icon";
+import { StoreModule } from "@ngrx/store";
+import { datasetsReducer } from "state-management/reducers/datasets.reducer";
 import { ADAuthService } from "users/adauth.service";
 import { BatchCardComponent } from "./batch-card.component";
 
@@ -12,6 +14,7 @@ import { BatchCardComponent } from "./batch-card.component";
     MatButtonModule,
     MatCardModule,
     MatIconModule,
+    StoreModule.forFeature("datasets", datasetsReducer)
   ],
   declarations: [
     BatchCardComponent

--- a/src/app/datasets/datasets.module.ts
+++ b/src/app/datasets/datasets.module.ts
@@ -3,7 +3,6 @@ import { EffectsModule } from "@ngrx/effects";
 import { AppConfigModule } from "app-config.module";
 import { LinkyModule } from "ngx-linky";
 import { ArchivingService } from "./archiving.service";
-import { BatchCardComponent } from "./batch-card/batch-card.component";
 import { BatchViewComponent } from "./batch-view/batch-view.component";
 import { AsyncPipe, CommonModule } from "@angular/common";
 import { FlexLayoutModule } from "@angular/flex-layout";
@@ -74,6 +73,7 @@ import { SampleEffects } from "state-management/effects/samples.effects";
 import { samplesReducer } from "state-management/reducers/samples.reducer";
 import { PublishedDataEffects } from "state-management/effects/published-data.effects";
 import { publishedDataReducer } from "state-management/reducers/published-data.reducer";
+import { BatchCardModule } from "./batch-card/batch-card.module";
 
 @NgModule({
   imports: [
@@ -112,6 +112,7 @@ import { publishedDataReducer } from "state-management/reducers/published-data.r
     ReactiveFormsModule,
     RouterModule,
     SharedCatanieModule,
+    BatchCardModule,
     StoreModule.forFeature("datasets", datasetsReducer),
     StoreModule.forFeature("jobs", jobsReducer),
     EffectsModule.forFeature([UserEffects]),
@@ -124,7 +125,6 @@ import { publishedDataReducer } from "state-management/reducers/published-data.r
         LogbooksModule,
   ],
   declarations: [
-    BatchCardComponent,
     BatchViewComponent,
     DashboardComponent,
     DatablocksComponent,
@@ -164,7 +164,6 @@ import { publishedDataReducer } from "state-management/reducers/published-data.r
     DatasetDetailComponent,
     DatasetTableComponent,
     DatasetsFilterComponent,
-    BatchCardComponent,
   ],
 })
 export class DatasetsModule {}

--- a/src/app/datasets/datasets.module.ts
+++ b/src/app/datasets/datasets.module.ts
@@ -65,6 +65,13 @@ import { AnonymousDetailsComponent } from "./anonymous-details/anonymous-details
 import { SampleEditComponent } from "./sample-edit/sample-edit.component";
 import { LuxonDateAdapter, MAT_LUXON_DATE_FORMATS } from "ngx-material-luxon";
 import { MatDatepickerModule } from "@angular/material/datepicker";
+import { UserEffects } from "state-management/effects/user.effects";
+import { ADAuthService } from "users/adauth.service";
+import { FileSizePipe } from "shared/pipes/filesize.pipe";
+import { ProposalEffects } from "state-management/effects/proposals.effects";
+import { proposalsReducer } from "state-management/reducers/proposals.reducer";
+import { SampleEffects } from "state-management/effects/samples.effects";
+import { samplesReducer } from "state-management/reducers/samples.reducer";
 
 @NgModule({
   imports: [
@@ -105,6 +112,11 @@ import { MatDatepickerModule } from "@angular/material/datepicker";
     SharedCatanieModule,
     StoreModule.forFeature("datasets", datasetsReducer),
     StoreModule.forFeature("jobs", jobsReducer),
+    EffectsModule.forFeature([UserEffects]),
+    EffectsModule.forFeature([ProposalEffects]),
+    StoreModule.forFeature("proposals", proposalsReducer),
+    EffectsModule.forFeature([SampleEffects]),
+    StoreModule.forFeature("samples", samplesReducer),
     LogbooksModule,
   ],
   declarations: [
@@ -131,6 +143,8 @@ import { MatDatepickerModule } from "@angular/material/datepicker";
   providers: [
     ArchivingService,
     AsyncPipe,
+    ADAuthService,
+    FileSizePipe,
     {
       provide: DateAdapter,
       useClass: LuxonDateAdapter,

--- a/src/app/datasets/datasets.module.ts
+++ b/src/app/datasets/datasets.module.ts
@@ -72,6 +72,8 @@ import { ProposalEffects } from "state-management/effects/proposals.effects";
 import { proposalsReducer } from "state-management/reducers/proposals.reducer";
 import { SampleEffects } from "state-management/effects/samples.effects";
 import { samplesReducer } from "state-management/reducers/samples.reducer";
+import { PublishedDataEffects } from "state-management/effects/published-data.effects";
+import { publishedDataReducer } from "state-management/reducers/published-data.reducer";
 
 @NgModule({
   imports: [
@@ -117,7 +119,9 @@ import { samplesReducer } from "state-management/reducers/samples.reducer";
     StoreModule.forFeature("proposals", proposalsReducer),
     EffectsModule.forFeature([SampleEffects]),
     StoreModule.forFeature("samples", samplesReducer),
-    LogbooksModule,
+    EffectsModule.forFeature([PublishedDataEffects]),
+    StoreModule.forFeature("publishedData", publishedDataReducer),
+        LogbooksModule,
   ],
   declarations: [
     BatchCardComponent,

--- a/src/app/samples/samples.module.ts
+++ b/src/app/samples/samples.module.ts
@@ -20,6 +20,7 @@ import { FlexLayoutModule } from "@angular/flex-layout";
 import { NgxJsonViewerModule } from "ngx-json-viewer";
 import { SharedCatanieModule } from "shared/shared.module";
 import { MatChipsModule } from "@angular/material/chips";
+import { FileSizePipe } from "shared/pipes/filesize.pipe";
 
 @NgModule({
   imports: [
@@ -47,6 +48,8 @@ import { MatChipsModule } from "@angular/material/chips";
     SampleDialogComponent,
     SampleDashboardComponent,
   ],
-  providers: [],
+  providers: [
+    FileSizePipe
+  ],
 })
 export class SamplesModule {}

--- a/src/app/shared/modules/breadcrumb/breadcrumb.component.ts
+++ b/src/app/shared/modules/breadcrumb/breadcrumb.component.ts
@@ -70,7 +70,7 @@ export class BreadcrumbComponent implements OnInit {
   setBreadcrumbs(): void {
     this.breadcrumbs = [];
     const children = this.route.children.reduce<ActivatedRoute[]>((accumulator, child) => {
-      accumulator.push(child, ...child.children)
+      accumulator.push(child, ...child.children);
       return accumulator;
     }, []);
     children.forEach((root) => {

--- a/src/app/shared/modules/breadcrumb/breadcrumb.component.ts
+++ b/src/app/shared/modules/breadcrumb/breadcrumb.component.ts
@@ -69,7 +69,11 @@ export class BreadcrumbComponent implements OnInit {
    */
   setBreadcrumbs(): void {
     this.breadcrumbs = [];
-    this.route.children.forEach((root) => {
+    const children = this.route.children.reduce<ActivatedRoute[]>((accumulator, child) => {
+      accumulator.push(child, ...child.children)
+      return accumulator;
+    }, []);
+    children.forEach((root) => {
       let param: string;
       Object.keys(root.snapshot.params).forEach((key) => {
         param = root.snapshot.params[key];

--- a/src/app/shared/modules/table/table.component.scss
+++ b/src/app/shared/modules/table/table.component.scss
@@ -26,7 +26,7 @@
     }
   }
 
-  .smallData {
+  mat-card.smallData {
     display: none;
   }
 }
@@ -36,7 +36,7 @@
     display: none;
   }
 
-  .smallData {
+  mat-card.smallData {
     margin: 1em 0;
 
     .title {

--- a/src/app/shared/services/date-time.service.spec.ts
+++ b/src/app/shared/services/date-time.service.spec.ts
@@ -57,4 +57,9 @@ describe("DateTimeService", () => {
     expect(service.isValidDateTime(input3)).toBeFalse();
     expect(service.isValidDateTime(input4)).toBeFalse();
   });
+
+  it("should return false when input is null", () => {
+    expect(service.isISODateTime(null)).toBeFalse();
+    expect(service.isValidDateTime(null)).toBeFalse();
+  });
 });

--- a/src/app/shared/services/date-time.service.ts
+++ b/src/app/shared/services/date-time.service.ts
@@ -20,6 +20,9 @@ export class DateTimeService {
     return DateTime.fromJSDate(input).isValid;
   }
   isISODateTime(input: string){
+    if (!input) {
+      return false;
+    }
     const regex = /^\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)$/g;
     if(input.match(regex) && DateTime.fromISO(input).isValid){
       return true;

--- a/src/app/shared/services/date-time.service.ts
+++ b/src/app/shared/services/date-time.service.ts
@@ -5,7 +5,7 @@ import {DateTime} from "luxon";
   providedIn: "root"
 })
 export class DateTimeService {
-  isValidDateTime(input: string | Date){
+  isValidDateTime(input: string | Date | null){
     if (!input) {
       return false;
     }
@@ -19,7 +19,7 @@ export class DateTimeService {
     }
     return DateTime.fromJSDate(input).isValid;
   }
-  isISODateTime(input: string){
+  isISODateTime(input: string | null){
     if (!input) {
       return false;
     }


### PR DESCRIPTION
## Description
This PR tries to reduce the bundle size and lazy load modules.
## Motivation

### Optimizing bundle size

How we import modules has big impact on the bundle size. One example is that we need to use `batch-card` component in `LayoutModule`. If we import the `DatasetsModule` into `LayoutModule` it will increase the size of `main.js` by ~1MB comparing with only importing the `BatchCardModule`. I tried very hard to reduce the bundle size however it is impossible to reduce the size of the shared module because it uses `exceljs` which is more than 1 MB in production build.
After working with this PR I learned that:
- It is better to have one modules per component instead of having multiple components in one module. 
- If we just want to use a single component in a module with multiple components then it is better to creating a module for that component and just import it. 
- Unused imported modules also increasing the bundle size so we should remove them (It is sad that angular doesn't have warning for these).

### Lazy loading

There might be some questions about why I created  `lazy` folder (solution 1) instead of just adding routing files to modules across the app (solution 2). I tried both solution and they both have advantages and disadvantages but I think solution one is better because:
- It is easier to have an overview on the routing tree, on which routes we have
- It is easier to avoid accidentally importing routing modules in other modules (which can causing bugs if we do)
## Changes:
- Lazy load modules
- Optimized bundle size by removing unused import and importing individual components
Bundle size for production build after optimization 
![Screenshot 2021-08-17 at 11 59 20](https://user-images.githubusercontent.com/17545757/129706104-0f1be928-f1bf-4c94-9561-882569d48bbf.png)
## For reviewers
- There are some routes that MAXIV doesn't have or doesn't data for them to show up properly so please try them out to see if they work as expected. These are /instruments(child paths) and /logbooks (child paths)
- In the `*.routing.module.ts` I added comments on some routes that we might not need anymore. If you don't have any objection I am thinking on removing them.
- Are these paths still relevant or we should remove them? `help/ingestManual, help/ingestManual, help/ingestManual, SciCatGettingStartedSLSSummary `

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

